### PR TITLE
Release1.0#157 qa/upload page

### DIFF
--- a/src/@components/@common/uploadHeader.tsx
+++ b/src/@components/@common/uploadHeader.tsx
@@ -2,67 +2,34 @@ import styled from "styled-components";
 import { UploadInfo } from "../../core/api/upload";
 import { UploadBackIc, UploadBtnIc, CanUploadBtnIc } from "../../assets";
 import { useNavigate } from "react-router-dom";
-import {
-  uploadTitle,
-  uploadCategory,
-  uploadIntroduce,
-  uploadKeyword,
-  uploadTrackJacketImage,
-  uploadVocalJacketImage,
-  uploadWavFile,
-  defaultImageState,
-} from "../../recoil/upload";
-import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
+import { useRecoilState } from "recoil";
 import { useEffect, useState } from "react";
 import { useMutation } from "react-query";
 import { UploadData } from "../../type/uploadData";
 import { currentUser } from "../../core/constants/userType";
 import { uploadButtonClickedInTrackList } from "../../recoil/uploadButtonClicked";
+import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
 
 interface PropsType {
   userType: string;
   producerUploadType: string | undefined;
+  uploadData: UploadInfoDataType;
+  setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
+  uploadDataRef: UploadInfoRefType;
 }
 
 export default function UploadHeader(props: PropsType) {
-  const { userType, producerUploadType } = props;
-  const jacketImageKey = userType === currentUser.PRODUCER ? uploadTrackJacketImage : uploadVocalJacketImage;
+  const { userType, producerUploadType, uploadData, setUploadData, uploadDataRef } = props;
+
   const navigate = useNavigate();
+
   const [openModal, setOpenModal] = useRecoilState<boolean>(uploadButtonClickedInTrackList);
-  const [image, setImage] = useRecoilState(jacketImageKey);
-
-  let formdata = new FormData();
-  formdata.append("defaultImage", image);
-
-  const postData: UploadData = {
-    title: useRecoilValue(uploadTitle),
-    category: useRecoilValue(uploadCategory),
-    wavFile: useRecoilValue(uploadWavFile),
-    introduce: useRecoilValue(uploadIntroduce),
-    keyword: useRecoilValue(uploadKeyword),
-    jacketImage: useRecoilValue(defaultImageState) ? formdata : image,
-  };
-
-  const resetTitle = useResetRecoilState(uploadTitle);
-  const resetCategory = useResetRecoilState(uploadCategory);
-  const resetWavFile = useResetRecoilState(uploadWavFile);
-  const resetIntroduce = useResetRecoilState(uploadIntroduce);
-  const resetKeyword = useResetRecoilState(uploadKeyword);
-  const resetJacketImage = useResetRecoilState(jacketImageKey);
-  const resetDefaultState = useResetRecoilState(defaultImageState);
 
   const [isUploadActive, setIsUploadActive] = useState<boolean>(false);
 
   const { mutate } = useMutation(post, {
     onSuccess: () => {
       navigate(-1);
-      resetTitle();
-      resetCategory();
-      resetWavFile();
-      resetIntroduce();
-      resetKeyword();
-      resetJacketImage();
-      resetDefaultState();
       userType === "producer" ? navigate(-1) : navigate("/vocal-profile/1");
     },
     onError: (error) => {
@@ -71,11 +38,11 @@ export default function UploadHeader(props: PropsType) {
   });
 
   async function post() {
-    if (postData.wavFile !== null) {
-      console.log(postData);
-      const data = await UploadInfo(postData, userType, producerUploadType);
-      return data;
-    }
+    // if (postData.wavFile !== null) {
+    //   console.log(postData);
+    //   const data = await UploadInfo(postData, userType, producerUploadType);
+    //   return data;
+    // }
   }
 
   function backPage(e: React.MouseEvent<SVGSVGElement>) {
@@ -87,19 +54,36 @@ export default function UploadHeader(props: PropsType) {
     if (isUploadActive) {
       mutate();
     }
+    console.log(uploadData);
   }
-  useEffect(() => {
-    if (
-      postData.title !== "" &&
-      postData.category !== "" &&
-      postData.wavFile !== null &&
-      postData.keyword.length !== 0
-    ) {
+
+  function checkMeetConditions(): void {
+    if (!isEmptyTitle() && !isEmptyCategory() && !isEmptyWavFile() && !isEmptyKeyword()) {
       setIsUploadActive(true);
     } else {
       setIsUploadActive(false);
     }
-  }, [postData.title, postData.category, postData.wavFile, postData.introduce, postData.keyword]);
+  }
+
+  function isEmptyTitle(): boolean {
+    return uploadData.title === "";
+  }
+
+  function isEmptyCategory(): boolean {
+    return uploadData.category === "Select";
+  }
+
+  function isEmptyWavFile(): boolean {
+    return uploadData.wavFile === null;
+  }
+
+  function isEmptyKeyword(): boolean {
+    return uploadData.keyword.length === 0;
+  }
+
+  useEffect(() => {
+    checkMeetConditions();
+  }, [uploadData]);
 
   return (
     <Container>

--- a/src/@components/@common/uploadHeader.tsx
+++ b/src/@components/@common/uploadHeader.tsx
@@ -5,10 +5,9 @@ import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
 import { useEffect, useState } from "react";
 import { useMutation } from "react-query";
-import { UploadData } from "../../type/uploadData";
-import { currentUser } from "../../core/constants/userType";
 import { uploadButtonClickedInTrackList } from "../../recoil/uploadButtonClicked";
 import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
+import { isMaker } from "../../utils/common/userType";
 
 interface PropsType {
   userType: string;
@@ -24,13 +23,11 @@ export default function UploadHeader(props: PropsType) {
   const navigate = useNavigate();
 
   const [openModal, setOpenModal] = useRecoilState<boolean>(uploadButtonClickedInTrackList);
-
   const [isUploadActive, setIsUploadActive] = useState<boolean>(false);
 
   const { mutate } = useMutation(post, {
     onSuccess: () => {
-      navigate(-1);
-      userType === "producer" ? navigate(-1) : navigate("/vocal-profile/1");
+      isMaker(userType) ? navigate(-1) : navigate("/vocal-profile/1");
     },
     onError: (error) => {
       console.log("에러!!", error);
@@ -38,11 +35,7 @@ export default function UploadHeader(props: PropsType) {
   });
 
   async function post() {
-    // if (postData.wavFile !== null) {
-    //   console.log(postData);
-    //   const data = await UploadInfo(postData, userType, producerUploadType);
-    //   return data;
-    // }
+    return await UploadInfo(uploadData, userType, producerUploadType);
   }
 
   function backPage(e: React.MouseEvent<SVGSVGElement>) {
@@ -51,10 +44,13 @@ export default function UploadHeader(props: PropsType) {
 
   function upload(e: React.MouseEvent<SVGSVGElement>) {
     setOpenModal(false);
+
+    setUploadData((prevState) => {
+      return { ...prevState, introduce: uploadDataRef.introduceRef?.current!.value };
+    });
     if (isUploadActive) {
       mutate();
     }
-    console.log(uploadData);
   }
 
   function checkMeetConditions(): void {

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -17,6 +17,7 @@ import {
 import { useRecoilState } from "recoil";
 import { uploadTitle, uploadCategory, uploadIntroduce, uploadKeyword, uploadWavFile } from "../../recoil/upload";
 import { checkMaxInputLength } from "../../utils/uploadPage/maxLength";
+import { isEnterKey, isMouseEnter, isFocus } from "../../utils/common/eventType";
 import { isClickedOutside } from "../../utils/common/modal";
 
 export default function UploadInfo() {
@@ -69,7 +70,7 @@ export default function UploadInfo() {
   }
 
   function hoverTitle(e: React.FocusEvent<HTMLInputElement>) {
-    if (isFocusType(e.type)) {
+    if (isFocus(e)) {
       setTitleHoverState(true);
     } else {
       titleLength === 0 ? setTitleHoverState(false) : setTitleHoverState(true);
@@ -132,20 +133,12 @@ export default function UploadInfo() {
 
   function hoverCategoryMenu(e: React.MouseEvent<HTMLLIElement>, index: number) {
     const hoverMenu = new Array(CATEGORY.length).fill(false);
-    if (isMouseEnterType(e.type)) {
+    if (isMouseEnter(e)) {
       hoverMenu[index] = true;
       setCheckHoverState([...hoverMenu]);
     } else {
       setCheckHoverState([...hoverMenu]);
     }
-  }
-
-  function isMouseEnterType(type: string): boolean {
-    return type === "mouseenter";
-  }
-
-  function isFocusType(type: string): boolean {
-    return type === "focus";
   }
 
   //해시태그
@@ -185,12 +178,8 @@ export default function UploadInfo() {
     return hashtags.length < 3;
   }
 
-  function checkEnterKey(e: React.KeyboardEvent<HTMLInputElement>): boolean {
-    return e.key === "Enter";
-  }
-
   function addHashtagEnterKey(e: React.KeyboardEvent<HTMLInputElement>): void {
-    checkEnterKey(e) && addHashtag();
+    isEnterKey(e) && addHashtag();
   }
 
   function restrictInput(ref: any): void {
@@ -215,7 +204,7 @@ export default function UploadInfo() {
   }
 
   function hoverWarningState(e: React.MouseEvent<HTMLInputElement>) {
-    isMouseEnterType(e.type) ? setWarningHoverState(true) : setWarningHoverState(false);
+    isMouseEnter(e) ? setWarningHoverState(true) : setWarningHoverState(false);
   }
 
   //소개글
@@ -241,7 +230,7 @@ export default function UploadInfo() {
   function hoverDescription(e: React.FocusEvent<HTMLTextAreaElement>) {
     const inputLength = e.target.value.length;
 
-    if (isFocusType(e.type)) {
+    if (isFocus(e)) {
       setDescriptionHoverState(true);
     } else {
       inputLength === 0 ? setDescriptionHoverState(false) : setDescriptionHoverState(true);

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -92,27 +92,23 @@ export default function UploadInfo() {
       : alert("확장자를 확인해 주세요!");
   }
 
-  function selectCategory(e: React.MouseEvent<HTMLLIElement>) {
-    const index = CATEGORY.indexOf(e.currentTarget.innerText);
-    setGenre(e.currentTarget.innerText);
-
+  function selectCategory(e: React.MouseEvent<HTMLLIElement>, index: number) {
     const temp = new Array(CATEGORY.length).fill(false);
     temp[index] = true;
     setCheckState([...temp]);
     setCheckStateIcon([...temp]);
     setCategoryState(true);
     setHiddenDropBox(true);
+    setGenre(e.currentTarget.innerText);
   }
 
-  function hoverMenu(e: React.MouseEvent<HTMLLIElement>) {
-    const index = CATEGORY.indexOf(e.currentTarget.innerText);
+  function hoverCategoryMenu(e: React.MouseEvent<HTMLLIElement>, index: number) {
+    const hoverMenu = new Array(CATEGORY.length).fill(false);
     if (e.type === "mouseenter") {
-      const temp = new Array(CATEGORY.length).fill(false);
-      temp[index] = true;
-      setCheckHoverState([...temp]);
+      hoverMenu[index] = true;
+      setCheckHoverState([...hoverMenu]);
     } else {
-      const temp = new Array(CATEGORY.length).fill(false);
-      setCheckHoverState([...temp]);
+      setCheckHoverState([...hoverMenu]);
     }
   }
 
@@ -410,9 +406,9 @@ export default function UploadInfo() {
             <DropMenuItem
               checkState={checkState[index]}
               checkHoverState={checkHoverState[index]}
-              onMouseEnter={hoverMenu}
-              onMouseLeave={hoverMenu}
-              onClick={selectCategory}
+              onMouseEnter={(e) => hoverCategoryMenu(e, index)}
+              onMouseLeave={(e) => hoverCategoryMenu(e, index)}
+              onClick={(e) => selectCategory(e, index)}
               ref={(element) => {
                 categoryRefs.current[index] = element;
               }}>

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -225,8 +225,6 @@ export default function UploadInfo(props: propsType) {
     resetHashtagInputWidth();
   }
 
-  console.log(uploadData.keyword);
-
   function hoverWarningState(e: React.MouseEvent<HTMLInputElement>) {
     isMouseEnter(e) ? setWarningHoverState(true) : setWarningHoverState(false);
   }

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -55,7 +55,7 @@ export default function UploadInfo() {
   const [warningHoverState, setWarningHoverState] = useState<boolean>(false);
 
   function hoverTitle(e: React.FocusEvent<HTMLInputElement>) {
-    e.type === "focus"
+    isFocusType(e.type)
       ? setTitleHoverState(true)
       : titleLength === 0
       ? setTitleHoverState(false)
@@ -112,7 +112,7 @@ export default function UploadInfo() {
 
   function hoverCategoryMenu(e: React.MouseEvent<HTMLLIElement>, index: number) {
     const hoverMenu = new Array(CATEGORY.length).fill(false);
-    if (checkMouseEnterType(e.type)) {
+    if (isMouseEnterType(e.type)) {
       hoverMenu[index] = true;
       setCheckHoverState([...hoverMenu]);
     } else {
@@ -120,16 +120,20 @@ export default function UploadInfo() {
     }
   }
 
-  function checkMouseEnterType(type : string): boolean {
+  function isMouseEnterType(type: string): boolean {
     return type === "mouseenter";
   }
 
+  function isFocusType(type: string): boolean {
+    return type === "focus";
+  }
+
   function hoverWarningState(e: React.MouseEvent<HTMLInputElement>) {
-    checkMouseEnterType(e.type) ? setWarningHoverState(true) : setWarningHoverState(false);
+    isMouseEnterType(e.type) ? setWarningHoverState(true) : setWarningHoverState(false);
   }
 
   function hoverDescription(e: React.FocusEvent<HTMLTextAreaElement>) {
-    e.type === "focus"
+    isFocusType(e.type)
       ? setDescriptionTitleHoverState(true)
       : descriptionTextarea.current!.value.length === 0
       ? setDescriptionTitleHoverState(false)
@@ -150,7 +154,7 @@ export default function UploadInfo() {
     setHashtagInputWidth(8.827);
   }
 
-  function resetHashtagCurrentValue(): void{
+  function resetHashtagCurrentValue(): void {
     enteredHashtag.current!.value = "";
   }
 
@@ -176,7 +180,7 @@ export default function UploadInfo() {
     return e.key === "Enter";
   }
 
-  function addHashtagEnterKey(e: React.KeyboardEvent<HTMLInputElement>):void {
+  function addHashtagEnterKey(e: React.KeyboardEvent<HTMLInputElement>): void {
     checkEnterKey(e) && addHashtag();
   }
 
@@ -205,7 +209,7 @@ export default function UploadInfo() {
 
   function deleteHashtag(index: number) {
     const deleteTag = [...hashtags];
-    deleteTag.splice(index,index+1);
+    deleteTag.splice(index, index + 1);
     setHashtags([...deleteTag]);
     resetHashtaInputWidth();
   }

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -41,8 +41,6 @@ export default function UploadInfo(props: propsType) {
   const [checkHoverState, setCheckHoverState] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
   const [checkStateIcon, setCheckStateIcon] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
 
-  const [hashtags, setHashtags] = useState<Array<string>>([]);
-
   const [hiddenDropBox, setHiddenDropBox] = useState<boolean>(true);
   const [fileName, setFileName] = useState<string>("");
   const [isTextOverflow, setIsTextOverflow] = useState<boolean>(false);
@@ -64,7 +62,7 @@ export default function UploadInfo(props: propsType) {
   //타이틀
   function changeTitleText(e: React.ChangeEvent<HTMLInputElement>) {
     const inputLength = e.target.value.length;
-    if (checkMaxInputLength(inputLength, 37)) {
+    if (checkMaxInputLength(inputLength, 36)) {
       setTitleLength(inputLength);
       setUploadData((prevState) => {
         return { ...prevState, title: e.target.value };
@@ -127,7 +125,7 @@ export default function UploadInfo(props: propsType) {
   }
 
   function setAudioAttribute(name: string, type: string, editName: string) {
-    if (checkMaxInputLength(editName.length, 14)) {
+    if (checkMaxInputLength(editName.length, 13)) {
       setIsTextOverflow(false);
       setFileName(name);
     } else {
@@ -163,9 +161,7 @@ export default function UploadInfo(props: propsType) {
   //해시태그
   function appendHashtag(): void {
     const hashtag = getEnteredHashtag();
-
     if (!isDuplicateHashtag(hashtag)) {
-      setHashtags([...hashtags, hashtag]);
       setUploadData((prevState) => {
         return { ...prevState, keyword: [...uploadData.keyword, hashtag] };
       });
@@ -187,7 +183,7 @@ export default function UploadInfo(props: propsType) {
   }
 
   function isDuplicateHashtag(value: string): boolean {
-    const isDuplicate = hashtags.includes(value);
+    const isDuplicate = uploadData.keyword.includes(value);
     isDuplicate && alert("중복된 해시태그 입니다!");
     return isDuplicate;
   }
@@ -197,7 +193,7 @@ export default function UploadInfo(props: propsType) {
   }
 
   function isMaxHashtags(): boolean {
-    return hashtags.length < 3;
+    return uploadData.keyword.length < 3;
   }
 
   function addHashtagEnterKey(e: React.KeyboardEvent<HTMLInputElement>): void {
@@ -211,7 +207,7 @@ export default function UploadInfo(props: propsType) {
   function changeHashtagTextWidth(e: React.ChangeEvent<HTMLInputElement>) {
     const inputLength = e.target.value.length;
 
-    if (checkMaxInputLength(inputLength, 11)) {
+    if (checkMaxInputLength(inputLength, 10)) {
       setHashtagLength(inputLength);
       setHashtagInputWidth(Number(e.target.value));
     } else {
@@ -220,8 +216,12 @@ export default function UploadInfo(props: propsType) {
   }
 
   function deleteHashtag(index: number) {
-    const deleteTag = [...hashtags].splice(index, 1);
-    setHashtags([...deleteTag]);
+    const deleteTag = uploadData.keyword;
+    deleteTag.splice(index, 1);
+
+    setUploadData((prevState) => {
+      return { ...prevState, keyword: deleteTag };
+    });
     resetHashtagInputWidth();
   }
 
@@ -229,17 +229,28 @@ export default function UploadInfo(props: propsType) {
     isMouseEnter(e) ? setWarningHoverState(true) : setWarningHoverState(false);
   }
 
+  function isEmptyHashtagInput(): boolean {
+    return enteredHashtag.current!.value.length === 0;
+  }
+
+  function changeHashtagInputWidth(inputWidth: number): void {
+    enteredHashtag!.current!.style.width = inputWidth / 10 + "rem";
+  }
+
+  function makeZeroInputWidth(width: number): void {
+    enteredHashtag!.current!.style.width = width + "rem";
+  }
+
   //소개글
   function resizeTextarea(e: React.ChangeEvent<HTMLTextAreaElement>) {
     const enterCount = e.target.value.split("\n").length;
     const inputLength = e.target.value.length;
     const currentHeight = introduceRef.current!.scrollHeight;
-    console.log(e.target.value);
 
     if (
-      checkMaxInputLength(enterCount, 8) &&
-      checkMaxInputLength(currentHeight, 201) &&
-      checkMaxInputLength(inputLength, 251)
+      checkMaxInputLength(enterCount, 7) &&
+      checkMaxInputLength(currentHeight, 200) &&
+      checkMaxInputLength(inputLength, 250)
     ) {
       setTextareaHeight(e.target.value);
       setDescriptionLength(inputLength);
@@ -258,36 +269,22 @@ export default function UploadInfo(props: propsType) {
     }
   }
 
-  useEffect(() => {
-    setUploadData((prevState) => {
-      return { ...prevState, keyword: hashtags };
-    });
-  }, [hashtags]);
+  function changeIntroduceInputHeight(scrollHeight: number): void {
+    introduceRef.current!.style.height = scrollHeight / 10 + "rem";
+  }
 
+  console.log(uploadData.keyword);
   useEffect(() => {
     if (introduceRef && introduceRef.current) {
-      introduceRef.current.style.height = "0rem";
+      introduceRef.current.style.height = 0 + "rem";
       const scrollHeight = introduceRef.current.scrollHeight;
-      introduceRef.current.style.height = scrollHeight / 10 + "rem";
+      changeIntroduceInputHeight(scrollHeight);
       setTextareaMargin(scrollHeight);
     }
   }, [textareaHeight]);
 
-  function isEmptyHashtagInput(): boolean {
-    return enteredHashtag.current!.value.length === 0;
-  }
-
-  function changeHashtagInputWidth(inputWidth: number): void {
-    enteredHashtag.current!.style.width = inputWidth / 10 + "rem";
-  }
-
-  function makeZeroInputWidth(width: number): void {
-    enteredHashtag.current!.style.width = width + "rem";
-  }
-
-  //존나빠르게 치면 이슈생김...
   useEffect(() => {
-    if (checkMaxInputLength(hashtags.length, 2) && !isEmptyHashtagInput()) {
+    if (checkMaxInputLength(uploadData.keyword.length, 1) && !isEmptyHashtagInput()) {
       makeZeroInputWidth(0);
       const inputWidth = enteredHashtag.current!.scrollWidth;
       changeHashtagInputWidth(inputWidth);
@@ -375,9 +372,9 @@ export default function UploadInfo(props: propsType) {
           </NameBox>
           <InputBox>
             <InputWrapper>
-              {hashtags.length > 0 ? (
+              {uploadData.keyword.length > 0 ? (
                 <>
-                  {hashtags.map((item: string, index: number) => {
+                  {uploadData.keyword.map((item: string, index: number) => {
                     return (
                       <InputHashtagWrapper>
                         <Hashtag key={index}>
@@ -389,7 +386,7 @@ export default function UploadInfo(props: propsType) {
                       </InputHashtagWrapper>
                     );
                   })}
-                  {hashtags.length < 3 && (
+                  {isMaxHashtags() && (
                     <InputHashtagWrapper>
                       <Hashtag>
                         <HashtagWrapper>

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -18,27 +18,18 @@ import { useRecoilState } from "recoil";
 import { uploadTitle, uploadCategory, uploadIntroduce, uploadKeyword, uploadWavFile } from "../../recoil/upload";
 
 export default function UploadInfo() {
+  const CATEGORY: string[] = ["R&B", "Hiphop", "Ballad", "Pop", "Rock", "EDM", "Jazz", "House", "Funk"];
+
   const titleRef = useRef<HTMLInputElement>(null);
   const descriptionTextarea = useRef<HTMLTextAreaElement | null>(null);
   const dropBoxRef = useRef<HTMLDivElement>(null);
   let enteredHashtag = useRef<HTMLInputElement | null>(null);
   let categoryRefs = useRef<HTMLLIElement[] | null[]>([]);
 
-  const [category, setCategory] = useState<string[]>([
-    "R&B",
-    "Hiphop",
-    "Ballad",
-    "Pop",
-    "Rock",
-    "EDM",
-    "Jazz",
-    "House",
-    "Funk",
-  ]);
 
-  const [checkState, setCheckState] = useState<Array<boolean>>(new Array(category.length).fill(false));
-  const [checkHoverState, setCheckHoverState] = useState<Array<boolean>>(new Array(category.length).fill(false));
-  const [checkStateIcon, setCheckStateIcon] = useState<Array<boolean>>(new Array(category.length).fill(false));
+  const [checkState, setCheckState] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
+  const [checkHoverState, setCheckHoverState] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
+  const [checkStateIcon, setCheckStateIcon] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
 
   const [title, setTitle] = useRecoilState<string>(uploadTitle);
   const [description, setDeiscription] = useRecoilState<string>(uploadIntroduce);
@@ -97,10 +88,10 @@ export default function UploadInfo() {
   }
 
   function selectCategory(e: React.MouseEvent<HTMLLIElement>) {
-    const index = category.indexOf(e.currentTarget.innerText);
+    const index = CATEGORY.indexOf(e.currentTarget.innerText);
     setGenre(e.currentTarget.innerText);
 
-    const temp = new Array(category.length).fill(false);
+    const temp = new Array(CATEGORY.length).fill(false);
     temp[index] = true;
     setCheckState([...temp]);
     setCheckStateIcon([...temp]);
@@ -109,13 +100,13 @@ export default function UploadInfo() {
   }
 
   function hoverMenu(e: React.MouseEvent<HTMLLIElement>) {
-    const index = category.indexOf(e.currentTarget.innerText);
+    const index = CATEGORY.indexOf(e.currentTarget.innerText);
     if (e.type === "mouseenter") {
-      const temp = new Array(category.length).fill(false);
+      const temp = new Array(CATEGORY.length).fill(false);
       temp[index] = true;
       setCheckHoverState([...temp]);
     } else {
-      const temp = new Array(category.length).fill(false);
+      const temp = new Array(CATEGORY.length).fill(false);
       setCheckHoverState([...temp]);
     }
   }
@@ -211,7 +202,6 @@ export default function UploadInfo() {
         if (enteredHashtag && enteredHashtag.current) {
           enteredHashtag.current.style.width = "0rem";
           const inputWidth = enteredHashtag.current.scrollWidth;
-          console.log(inputWidth);
           enteredHashtag.current.style.width = inputWidth / 10 + "rem";
           setHashtagInputWidth(inputWidth);
         }
@@ -221,7 +211,7 @@ export default function UploadInfo() {
       }
     }
   }, [hashtagInputWidth]);
-  console.log();
+
 
   useEffect(() => {
     function clickOutside(e: any) {
@@ -234,7 +224,7 @@ export default function UploadInfo() {
       document.removeEventListener("click", clickOutside);
     };
   }, [hiddenDropBox]);
-  console.log(enteredHashtag.current?.scrollWidth);
+  
   return (
     <Container>
       <TitleInput
@@ -412,7 +402,7 @@ export default function UploadInfo() {
       </TextCount>
       <DropMenuBox hiddenDropBox={hiddenDropBox} onClick={closeDropBox} ref={dropBoxRef}>
         <DropMenuWrapper>
-          {category.map((text: string, index: number) => (
+          {CATEGORY.map((text: string, index: number) => (
             <DropMenuItem
               checkState={checkState[index]}
               checkHoverState={checkHoverState[index]}

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -26,7 +26,6 @@ export default function UploadInfo() {
   let enteredHashtag = useRef<HTMLInputElement | null>(null);
   let categoryRefs = useRef<HTMLLIElement[] | null[]>([]);
 
-
   const [checkState, setCheckState] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
   const [checkHoverState, setCheckHoverState] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
   const [checkStateIcon, setCheckStateIcon] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
@@ -38,7 +37,7 @@ export default function UploadInfo() {
   const [wavFile, setWavFile] = useRecoilState<File | null>(uploadWavFile);
 
   const [hiddenDropBox, setHiddenDropBox] = useState<boolean>(true);
-  const [editFileName, setEditFileName] = useState<string>("");
+  const [fileName, setFileName] = useState<string>("");
   const [isTextOverflow, setIsTextOverflow] = useState<boolean>(false);
   const [categoryState, setCategoryState] = useState<boolean>(false);
   const [audioType, setAudioType] = useState<string>("");
@@ -63,28 +62,34 @@ export default function UploadInfo() {
     setHiddenDropBox((prev) => !prev);
   }
 
-  function uploadFile(e: React.ChangeEvent<HTMLInputElement>) {
-    const uploadName = e.target.value.substring(e.target.value.lastIndexOf("\\") + 1);
-    const type = e.target.value.substring(e.target.value.lastIndexOf("\\") + 1).substring(uploadName.length - 4);
+  function checkAduioFileType(type: string) {
+    return type === ".mp3" || type === ".wav";
+  }
 
-    let str = e.target.value.substring(e.target.value.lastIndexOf("\\") + 1, e.target.value.length - 4);
-
-    if (type === ".mp3" || type === ".wav") {
-      if (str.length > 14) {
-        setIsTextOverflow(true);
-        setEditFileName(str);
-      } else {
-        setIsTextOverflow(false);
-        setEditFileName(uploadName);
-      }
-      setAudioType(type);
-
-      if (e.target.files !== null) {
-        setWavFile(e.target.files[0]);
-      }
+  function setAudioAttribute(name: string, type: string, editName: string) {
+    if (editName.length > 14) {
+      setIsTextOverflow(true);
+      setFileName(editName);
     } else {
-      alert("확장자를 확인해 주세요!");
+      setIsTextOverflow(false);
+      setFileName(name);
     }
+    setAudioType(type);
+  }
+
+  function uploadAudiofile(e: React.ChangeEvent<HTMLInputElement>) {
+    const audioFileName: string = e.target.value.substring(e.target.value.lastIndexOf("\\") + 1);
+    const audioFileType: string = e.target.value
+      .substring(e.target.value.lastIndexOf("\\") + 1)
+      .substring(audioFileName.length - 4);
+    const onlyFileName: string = e.target.value.substring(
+      e.target.value.lastIndexOf("\\") + 1,
+      e.target.value.length - 4,
+    );
+
+    checkAduioFileType(audioFileType)
+      ? setAudioAttribute(audioFileName, audioFileType, onlyFileName)
+      : alert("확장자를 확인해 주세요!");
   }
 
   function selectCategory(e: React.MouseEvent<HTMLLIElement>) {
@@ -212,7 +217,6 @@ export default function UploadInfo() {
     }
   }, [hashtagInputWidth]);
 
-
   useEffect(() => {
     function clickOutside(e: any) {
       if (!hiddenDropBox && !dropBoxRef.current!.contains(e.target)) {
@@ -224,7 +228,7 @@ export default function UploadInfo() {
       document.removeEventListener("click", clickOutside);
     };
   }, [hiddenDropBox]);
-  
+
   return (
     <Container>
       <TitleInput
@@ -252,15 +256,15 @@ export default function UploadInfo() {
           </NameBox>
           <InputBox>
             <InputWrapper>
-              <InputFileTextWrapper editFileName={editFileName}>
-                <FileName value={editFileName} isTextOverflow={isTextOverflow} disabled />
+              <InputFileTextWrapper fileName={fileName}>
+                <FileName value={fileName} isTextOverflow={isTextOverflow} disabled />
                 {isTextOverflow && <FileAttribute isTextOverflow={isTextOverflow}>{audioType}</FileAttribute>}
                 <input
                   type="file"
                   id="wavFileUpload"
                   style={{ display: "none" }}
                   accept=".wav,.mp3"
-                  onChange={uploadFile}
+                  onChange={uploadAudiofile}
                   readOnly
                 />
               </InputFileTextWrapper>
@@ -540,14 +544,14 @@ const FileAttribute = styled.div<{ isTextOverflow: boolean }>`
   margin-top: 1.686rem;
 `;
 
-const InputFileTextWrapper = styled.div<{ editFileName: string }>`
+const InputFileTextWrapper = styled.div<{ fileName: string }>`
   height: 4.7rem;
   width: 20.8rem;
 
   display: flex;
   align-items: center;
   border-bottom: 1px solid
-    ${(props) => (props.editFileName !== "" ? ({ theme }) => theme.colors.white : ({ theme }) => theme.colors.gray3)};
+    ${(props) => (props.fileName !== "" ? ({ theme }) => theme.colors.white : ({ theme }) => theme.colors.gray3)};
 `;
 
 const InputCategoryTextWrapper = styled.div<{ categoryState: boolean }>`

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -169,12 +169,12 @@ export default function UploadInfo(props: propsType) {
       setUploadData((prevState) => {
         return { ...prevState, keyword: [...uploadData.keyword, hashtag] };
       });
-      resetHashtaInputWidth();
+      resetHashtagInputWidth();
       resetHashtagCurrentValue();
     }
   }
 
-  function resetHashtaInputWidth(): void {
+  function resetHashtagInputWidth(): void {
     setHashtagInputWidth(HASHTAG_WIDTH);
   }
 
@@ -222,7 +222,7 @@ export default function UploadInfo(props: propsType) {
   function deleteHashtag(index: number) {
     const deleteTag = [...hashtags].splice(index, 1);
     setHashtags([...deleteTag]);
-    resetHashtaInputWidth();
+    resetHashtagInputWidth();
   }
 
   console.log(uploadData.keyword);
@@ -275,20 +275,28 @@ export default function UploadInfo(props: propsType) {
     }
   }, [textareaHeight]);
 
+  function isEmptyHashtagInput(): boolean {
+    return enteredHashtag.current!.value.length === 0;
+  }
+
+  function changeHashtagInputWidth(inputWidth: number): void {
+    enteredHashtag.current!.style.width = inputWidth / 10 + "rem";
+  }
+
+  function makeZeroInputWidth(width: number): void {
+    enteredHashtag.current!.style.width = width + "rem";
+  }
+
   //존나빠르게 치면 이슈생김...
   useEffect(() => {
-    if (hashtags.length < 3) {
-      if (enteredHashtag.current!.value.length > 0) {
-        if (enteredHashtag && enteredHashtag.current) {
-          enteredHashtag.current.style.width = "0rem";
-          const inputWidth = enteredHashtag.current.scrollWidth;
-          enteredHashtag.current.style.width = inputWidth / 10 + "rem";
-          setHashtagInputWidth(inputWidth);
-        }
-      } else {
-        enteredHashtag.current!.style.width = HASHTAG_WIDTH + "rem";
-        setHashtagInputWidth(HASHTAG_WIDTH);
-      }
+    if (checkMaxInputLength(hashtags.length, 2) && !isEmptyHashtagInput()) {
+      makeZeroInputWidth(0);
+      const inputWidth = enteredHashtag.current!.scrollWidth;
+      changeHashtagInputWidth(inputWidth);
+      setHashtagInputWidth(inputWidth);
+    } else {
+      makeZeroInputWidth(HASHTAG_WIDTH);
+      setHashtagInputWidth(HASHTAG_WIDTH);
     }
   }, [hashtagInputWidth]);
 

--- a/src/@components/upload/trackUpload.tsx
+++ b/src/@components/upload/trackUpload.tsx
@@ -4,66 +4,53 @@ import UploadInfo from "../@common/uploadInfo";
 import TrackUploadDefaultImg from "../../assets/image/trackUploadDefaultImg.png";
 import { FileChangeIc } from "../../assets";
 import { uploadImage, setHover } from "../../utils/uploadPage/uploadImage";
-import UploadHeader from "../@common/uploadHeader";
 import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
 
 interface PropsType {
-  userType: string;
-  producerUploadType: string | undefined;
   uploadData: UploadInfoDataType;
-  uploadDataRef: UploadInfoRefType;
   setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
   setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
 }
 
 export default function TrackUpload(props: PropsType) {
-  const { userType, producerUploadType, uploadData, uploadDataRef, setUploadData, setUploadDataRef } = props;
+  const { uploadData, setUploadData, setUploadDataRef } = props;
 
   const [trackUploadImg, setTrackUploadImg] = useState<string>(TrackUploadDefaultImg);
   const [isHover, setIsHover] = useState<boolean>(false);
 
   return (
-    <>
-      <UploadHeader
-        userType={userType}
-        producerUploadType={producerUploadType}
-        uploadData={uploadData}
-        setUploadData={setUploadData}
-        uploadDataRef={uploadDataRef}
-      />
-      <Container>
-        <SectionWrapper>
-          <TrackImageBox>
-            <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-              <TrackUploadImage
-                src={trackUploadImg}
-                alt="썸네일이미지"
+    <Container>
+      <SectionWrapper>
+        <TrackImageBox>
+          <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
+            <TrackUploadImage
+              src={trackUploadImg}
+              alt="썸네일이미지"
+              onMouseEnter={(e) => setHover(e, trackUploadImg, setIsHover)}
+              onMouseLeave={(e) => setHover(e, trackUploadImg, setIsHover)}
+              isHover={isHover}
+            />
+          </label>
+          <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
+            {isHover && (
+              <FileChangeIcon
                 onMouseEnter={(e) => setHover(e, trackUploadImg, setIsHover)}
                 onMouseLeave={(e) => setHover(e, trackUploadImg, setIsHover)}
-                isHover={isHover}
               />
-            </label>
-            <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-              {isHover && (
-                <FileChangeIcon
-                  onMouseEnter={(e) => setHover(e, trackUploadImg, setIsHover)}
-                  onMouseLeave={(e) => setHover(e, trackUploadImg, setIsHover)}
-                />
-              )}
-            </label>
-          </TrackImageBox>
-          <input
-            type="file"
-            id="imageFileUpload"
-            style={{ display: "none" }}
-            accept=".jpg,.jpeg,.png"
-            onChange={(e) => uploadImage(e, setTrackUploadImg, setUploadData)}
-            readOnly
-          />
-          <UploadInfo uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
-        </SectionWrapper>
-      </Container>
-    </>
+            )}
+          </label>
+        </TrackImageBox>
+        <input
+          type="file"
+          id="imageFileUpload"
+          style={{ display: "none" }}
+          accept=".jpg,.jpeg,.png"
+          onChange={(e) => uploadImage(e, setTrackUploadImg, setUploadData)}
+          readOnly
+        />
+        <UploadInfo uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
+      </SectionWrapper>
+    </Container>
   );
 }
 

--- a/src/@components/upload/trackUpload.tsx
+++ b/src/@components/upload/trackUpload.tsx
@@ -1,16 +1,28 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import styled, { css } from "styled-components";
 import UploadInfo from "../@common/uploadInfo";
-import { uploadTrackJacketImage, defaultImageState } from "../../recoil/upload";
-import { useRecoilState } from "recoil";
 import TrackUploadDefaultImg from "../../assets/image/trackUploadDefaultImg.png";
 import { FileChangeIc } from "../../assets";
 import { isMouseEnter } from "../../utils/common/eventType";
 import { uploadImage, isDefaultImage } from "../../utils/uploadPage/uploadImage";
-export default function TrackUpload() {
+import UploadHeader from "../@common/uploadHeader";
+import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
+
+interface propsType {
+  userType: string;
+  producerUploadType: string | undefined;
+  uploadData: UploadInfoDataType;
+  uploadDataRef: UploadInfoRefType;
+  setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
+  setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
+}
+
+export default function TrackUpload(props: propsType) {
+  const { userType, producerUploadType, uploadData, uploadDataRef, setUploadData, setUploadDataRef } = props;
+
+  const jacketImageRef = useRef<HTMLInputElement>(null);
+
   const [trackUploadImg, setTrackUploadImg] = useState<string>(TrackUploadDefaultImg);
-  const [tarckJacketImage, setTrackJacketImage] = useRecoilState<File | Blob>(uploadTrackJacketImage);
-  const [defaultState, setDefaultState] = useRecoilState<boolean>(defaultImageState);
   const [isHover, setIsHover] = useState<boolean>(false);
 
   function setHover(e: React.MouseEvent<HTMLDivElement | SVGSVGElement>) {
@@ -20,36 +32,46 @@ export default function TrackUpload() {
   }
 
   function uploadImageFile(e: React.ChangeEvent<HTMLInputElement>) {
-    uploadImage(e, setTrackUploadImg, setTrackJacketImage, setDefaultState);
+    uploadImage(e, setTrackUploadImg, setUploadData);
   }
   return (
-    <Container>
-      <SectionWrapper>
-        <TrackImageBox>
-          <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-            <TrackUploadImage
-              src={trackUploadImg}
-              alt="트랙이미지"
-              onMouseEnter={setHover}
-              onMouseLeave={setHover}
-              isHover={isHover}
-            />
-          </label>
-          <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-            {isHover && <FileChangeIcon onMouseEnter={setHover} onMouseLeave={setHover} />}
-          </label>
-        </TrackImageBox>
-        <input
-          type="file"
-          id="imageFileUpload"
-          style={{ display: "none" }}
-          accept=".jpg,.jpeg,.png"
-          onChange={uploadImageFile}
-          readOnly
-        />
-        <UploadInfo />
-      </SectionWrapper>
-    </Container>
+    <>
+      <UploadHeader
+        userType={userType}
+        producerUploadType={producerUploadType}
+        uploadData={uploadData}
+        setUploadData={setUploadData}
+        uploadDataRef={uploadDataRef}
+      />
+      <Container>
+        <SectionWrapper>
+          <TrackImageBox>
+            <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
+              <TrackUploadImage
+                src={trackUploadImg}
+                alt="트랙이미지"
+                onMouseEnter={setHover}
+                onMouseLeave={setHover}
+                isHover={isHover}
+              />
+            </label>
+            <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
+              {isHover && <FileChangeIcon onMouseEnter={setHover} onMouseLeave={setHover} />}
+            </label>
+          </TrackImageBox>
+          <input
+            type="file"
+            id="imageFileUpload"
+            style={{ display: "none" }}
+            accept=".jpg,.jpeg,.png"
+            onChange={uploadImageFile}
+            readOnly
+            ref={jacketImageRef}
+          />
+          <UploadInfo uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
+        </SectionWrapper>
+      </Container>
+    </>
   );
 }
 

--- a/src/@components/upload/trackUpload.tsx
+++ b/src/@components/upload/trackUpload.tsx
@@ -1,14 +1,13 @@
-import React, { useState, useRef } from "react";
+import React, { useState } from "react";
 import styled, { css } from "styled-components";
 import UploadInfo from "../@common/uploadInfo";
 import TrackUploadDefaultImg from "../../assets/image/trackUploadDefaultImg.png";
 import { FileChangeIc } from "../../assets";
-import { isMouseEnter } from "../../utils/common/eventType";
-import { uploadImage, isDefaultImage } from "../../utils/uploadPage/uploadImage";
+import { uploadImage, setHover } from "../../utils/uploadPage/uploadImage";
 import UploadHeader from "../@common/uploadHeader";
 import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
 
-interface propsType {
+interface PropsType {
   userType: string;
   producerUploadType: string | undefined;
   uploadData: UploadInfoDataType;
@@ -17,21 +16,12 @@ interface propsType {
   setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
 }
 
-export default function TrackUpload(props: propsType) {
+export default function TrackUpload(props: PropsType) {
   const { userType, producerUploadType, uploadData, uploadDataRef, setUploadData, setUploadDataRef } = props;
 
   const [trackUploadImg, setTrackUploadImg] = useState<string>(TrackUploadDefaultImg);
   const [isHover, setIsHover] = useState<boolean>(false);
 
-  function setHover(e: React.MouseEvent<HTMLDivElement | SVGSVGElement>) {
-    if (!isDefaultImage(trackUploadImg)) {
-      isMouseEnter(e) ? setIsHover(true) : setIsHover(false);
-    }
-  }
-
-  function uploadImageFile(e: React.ChangeEvent<HTMLInputElement>) {
-    uploadImage(e, setTrackUploadImg, setUploadData);
-  }
   return (
     <>
       <UploadHeader
@@ -48,13 +38,18 @@ export default function TrackUpload(props: propsType) {
               <TrackUploadImage
                 src={trackUploadImg}
                 alt="썸네일이미지"
-                onMouseEnter={setHover}
-                onMouseLeave={setHover}
+                onMouseEnter={(e) => setHover(e, trackUploadImg, setIsHover)}
+                onMouseLeave={(e) => setHover(e, trackUploadImg, setIsHover)}
                 isHover={isHover}
               />
             </label>
             <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-              {isHover && <FileChangeIcon onMouseEnter={setHover} onMouseLeave={setHover} />}
+              {isHover && (
+                <FileChangeIcon
+                  onMouseEnter={(e) => setHover(e, trackUploadImg, setIsHover)}
+                  onMouseLeave={(e) => setHover(e, trackUploadImg, setIsHover)}
+                />
+              )}
             </label>
           </TrackImageBox>
           <input
@@ -62,7 +57,7 @@ export default function TrackUpload(props: propsType) {
             id="imageFileUpload"
             style={{ display: "none" }}
             accept=".jpg,.jpeg,.png"
-            onChange={uploadImageFile}
+            onChange={(e) => uploadImage(e, setTrackUploadImg, setUploadData)}
             readOnly
           />
           <UploadInfo uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />

--- a/src/@components/upload/trackUpload.tsx
+++ b/src/@components/upload/trackUpload.tsx
@@ -20,13 +20,11 @@ interface propsType {
 export default function TrackUpload(props: propsType) {
   const { userType, producerUploadType, uploadData, uploadDataRef, setUploadData, setUploadDataRef } = props;
 
-  const jacketImageRef = useRef<HTMLInputElement>(null);
-
   const [trackUploadImg, setTrackUploadImg] = useState<string>(TrackUploadDefaultImg);
   const [isHover, setIsHover] = useState<boolean>(false);
 
   function setHover(e: React.MouseEvent<HTMLDivElement | SVGSVGElement>) {
-    if (isDefaultImage(trackUploadImg)) {
+    if (!isDefaultImage(trackUploadImg)) {
       isMouseEnter(e) ? setIsHover(true) : setIsHover(false);
     }
   }
@@ -49,7 +47,7 @@ export default function TrackUpload(props: propsType) {
             <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
               <TrackUploadImage
                 src={trackUploadImg}
-                alt="트랙이미지"
+                alt="썸네일이미지"
                 onMouseEnter={setHover}
                 onMouseLeave={setHover}
                 isHover={isHover}
@@ -66,7 +64,6 @@ export default function TrackUpload(props: propsType) {
             accept=".jpg,.jpeg,.png"
             onChange={uploadImageFile}
             readOnly
-            ref={jacketImageRef}
           />
           <UploadInfo uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
         </SectionWrapper>

--- a/src/@components/upload/trackUpload.tsx
+++ b/src/@components/upload/trackUpload.tsx
@@ -1,81 +1,27 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import styled, { css } from "styled-components";
 import UploadInfo from "../@common/uploadInfo";
 import { uploadTrackJacketImage, defaultImageState } from "../../recoil/upload";
 import { useRecoilState } from "recoil";
 import TrackUploadDefaultImg from "../../assets/image/trackUploadDefaultImg.png";
 import { FileChangeIc } from "../../assets";
-
+import { isMouseEnter } from "../../utils/common/eventType";
+import { uploadImage, isDefaultImage } from "../../utils/uploadPage/uploadImage";
 export default function TrackUpload() {
   const [trackUploadImg, setTrackUploadImg] = useState<string>(TrackUploadDefaultImg);
   const [tarckJacketImage, setTrackJacketImage] = useRecoilState<File | Blob>(uploadTrackJacketImage);
-  const [defaultstate, setDefaultState] = useRecoilState<boolean>(defaultImageState);
-
+  const [defaultState, setDefaultState] = useRecoilState<boolean>(defaultImageState);
   const [isHover, setIsHover] = useState<boolean>(false);
 
   function setHover(e: React.MouseEvent<HTMLDivElement | SVGSVGElement>) {
-    if (trackUploadImg !== TrackUploadDefaultImg) {
-      e.type === "mouseenter" ? setIsHover(true) : setIsHover(false);
+    if (isDefaultImage(trackUploadImg)) {
+      isMouseEnter(e) ? setIsHover(true) : setIsHover(false);
     }
   }
 
-  function uploadImage(e: React.ChangeEvent<HTMLInputElement>) {
-    const uploadName = e.target.value.substring(e.target.value.lastIndexOf("\\") + 1);
-
-    if (isImageType(uploadName)) {
-      if (e.target.value.length === 0) {
-        if (trackUploadImg === TrackUploadDefaultImg) {
-          setTrackUploadImg(TrackUploadDefaultImg);
-        } else {
-          return;
-        }
-      }
-
-      if (e.target.files !== null) {
-        const fileUrl = URL.createObjectURL(e.target.files[0]);
-        const imageSize = e.target.files[0].size;
-        if (checImageSize(imageSize)) {
-          setTrackUploadImg(fileUrl);
-          setTrackJacketImage(e.target.files[0]);
-          setDefaultState(false);
-        }
-      }
-    } else {
-      alert("확장자 명을 확인 해주세요!");
-    }
+  function uploadImageFile(e: React.ChangeEvent<HTMLInputElement>) {
+    uploadImage(e, setTrackUploadImg, setTrackJacketImage, setDefaultState);
   }
-
-  function checImageSize(imageSize: number): boolean {
-    if (imageSize > 5 * 1024 * 1024) {
-      alert("이미지 용량제한은 5MB 이하 입니다.");
-      return false;
-    } else {
-      return true;
-    }
-  }
-
-  function isImageType(uploadName: string) {
-    const fileType = uploadName.substring(uploadName.length - 4);
-    let isImageType;
-    fileType === ".jpg" || fileType === "jpeg" || fileType === ".png" ? (isImageType = true) : (isImageType = false);
-    return isImageType;
-  }
-
-  async function convertURLtoFile(url: string) {
-    const response = await fetch(url);
-    const data = await response.blob();
-    const ext = url.split(".").pop(); // url 구조에 맞게 수정할 것
-    const filename = url.split("/").pop(); // url 구조에 맞게 수정할 것
-    const metadata = { type: `image/${ext}` };
-    return new File([data], filename!, metadata);
-  }
-
-  useEffect(() => {
-    convertURLtoFile("../assets/image/trackUploadDefaultImg.png").then((data) => {
-      setTrackJacketImage(data);
-    });
-  }, []);
-
   return (
     <Container>
       <SectionWrapper>
@@ -98,7 +44,7 @@ export default function TrackUpload() {
           id="imageFileUpload"
           style={{ display: "none" }}
           accept=".jpg,.jpeg,.png"
-          onChange={uploadImage}
+          onChange={uploadImageFile}
           readOnly
         />
         <UploadInfo />

--- a/src/@components/upload/vocalUpload.tsx
+++ b/src/@components/upload/vocalUpload.tsx
@@ -21,7 +21,7 @@ export default function VocalUpload() {
   }
 
   function uploadImageFile(e: React.ChangeEvent<HTMLInputElement>) {
-    uploadImage(e, setVocalUploadImg, setVocalJacketImage, setDefaultState);
+    // uploadImage(e, setVocalUploadImg, setVocalJacketImage, setDefaultState);
   }
 
   return (
@@ -46,7 +46,7 @@ export default function VocalUpload() {
           readOnly
         />
 
-        <UploadInfo />
+        {/* <UploadInfo /> */}
       </SectionWrapper>
     </Container>
   );

--- a/src/@components/upload/vocalUpload.tsx
+++ b/src/@components/upload/vocalUpload.tsx
@@ -1,73 +1,54 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled, { css } from "styled-components";
 import UploadInfo from "../@common/uploadInfo";
+import { uploadVocalJacketImage, defaultImageState } from "../../recoil/upload";
+import { useRecoilState } from "recoil";
 import VocalUploadDefaultImg from "../../assets/image/vocalUploadDefaultImg.png";
 import VocalUploadFrameIc from "../../assets/icon/vocalUploadFrameIc.svg";
 import { FileChangeIc } from "../../assets";
-import { uploadImage, isDefaultImage } from "../../utils/uploadPage/uploadImage";
-import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
-import { isMouseEnter } from "../../utils/common/eventType";
-import UploadHeader from "../@common/uploadHeader";
+import { uploadImage } from "../../utils/uploadPage/uploadImage";
 
-interface propsType {
-  userType: string;
-  producerUploadType: string | undefined;
-  uploadData: UploadInfoDataType;
-  uploadDataRef: UploadInfoRefType;
-  setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
-  setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
-}
-
-export default function VocalUpload(props: propsType) {
-  const { userType, producerUploadType, uploadData, uploadDataRef, setUploadData, setUploadDataRef } = props;
-
+export default function VocalUpload() {
   const [vocalUploadImg, setVocalUploadImg] = useState<string>(VocalUploadDefaultImg);
+  const [vocalJacketImage, setVocalJacketImage] = useRecoilState<File | Blob>(uploadVocalJacketImage);
+  const [defaultState, setDefaultState] = useRecoilState<boolean>(defaultImageState);
   const [isHover, setIsHover] = useState<boolean>(false);
 
   function setHover(e: React.MouseEvent<HTMLDivElement | SVGSVGElement>) {
-    if (!isDefaultImage(vocalUploadImg)) {
-      isMouseEnter(e) ? setIsHover(true) : setIsHover(false);
+    if (vocalUploadImg !== VocalUploadDefaultImg) {
+      e.type === "mouseenter" ? setIsHover(true) : setIsHover(false);
     }
   }
 
   function uploadImageFile(e: React.ChangeEvent<HTMLInputElement>) {
-    uploadImage(e, setVocalUploadImg, setUploadData);
+    // uploadImage(e, setVocalUploadImg, setVocalJacketImage, setDefaultState);
   }
 
   return (
-    <>
-      <UploadHeader
-        userType={userType}
-        producerUploadType={producerUploadType}
-        uploadData={uploadData}
-        setUploadData={setUploadData}
-        uploadDataRef={uploadDataRef}
-      />
-      <Container>
-        <SectionWrapper>
-          <VocalImageBox>
-            <VocalImageFrame onMouseEnter={setHover} onMouseLeave={setHover}>
-              <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-                <VocalUploadImage src={vocalUploadImg} alt="썸네일이미지" isHover={isHover} />
-              </label>
-              <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-                {isHover && <FileChangeIcon onMouseEnter={setHover} onMouseLeave={setHover} />}
-              </label>
-            </VocalImageFrame>
-          </VocalImageBox>
-          <input
-            type="file"
-            id="imageFileUpload"
-            style={{ display: "none" }}
-            accept=".jpg,.jpeg,.png"
-            onChange={uploadImageFile}
-            readOnly
-          />
+    <Container>
+      <SectionWrapper>
+        <VocalImageBox>
+          <VocalImageFrame onMouseEnter={setHover} onMouseLeave={setHover}>
+            <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
+              <VocalUploadImage src={vocalUploadImg} alt="썸네일이미지" isHover={isHover} />
+            </label>
+            <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
+              {isHover && <FileChangeIcon onMouseEnter={setHover} onMouseLeave={setHover} />}
+            </label>
+          </VocalImageFrame>
+        </VocalImageBox>
+        <input
+          type="file"
+          id="imageFileUpload"
+          style={{ display: "none" }}
+          accept=".jpg,.jpeg,.png"
+          onChange={uploadImageFile}
+          readOnly
+        />
 
-          <UploadInfo uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
-        </SectionWrapper>
-      </Container>
-    </>
+        {/* <UploadInfo /> */}
+      </SectionWrapper>
+    </Container>
   );
 }
 

--- a/src/@components/upload/vocalUpload.tsx
+++ b/src/@components/upload/vocalUpload.tsx
@@ -4,9 +4,8 @@ import UploadInfo from "../@common/uploadInfo";
 import VocalUploadDefaultImg from "../../assets/image/vocalUploadDefaultImg.png";
 import VocalUploadFrameIc from "../../assets/icon/vocalUploadFrameIc.svg";
 import { FileChangeIc } from "../../assets";
-import { uploadImage, isDefaultImage } from "../../utils/uploadPage/uploadImage";
+import { uploadImage, setHover } from "../../utils/uploadPage/uploadImage";
 import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
-import { isMouseEnter } from "../../utils/common/eventType";
 import UploadHeader from "../@common/uploadHeader";
 
 interface propsType {
@@ -24,16 +23,6 @@ export default function VocalUpload(props: propsType) {
   const [vocalUploadImg, setVocalUploadImg] = useState<string>(VocalUploadDefaultImg);
   const [isHover, setIsHover] = useState<boolean>(false);
 
-  function setHover(e: React.MouseEvent<HTMLDivElement | SVGSVGElement>) {
-    if (!isDefaultImage(vocalUploadImg)) {
-      isMouseEnter(e) ? setIsHover(true) : setIsHover(false);
-    }
-  }
-
-  function uploadImageFile(e: React.ChangeEvent<HTMLInputElement>) {
-    uploadImage(e, setVocalUploadImg, setUploadData);
-  }
-
   return (
     <>
       <UploadHeader
@@ -46,12 +35,19 @@ export default function VocalUpload(props: propsType) {
       <Container>
         <SectionWrapper>
           <VocalImageBox>
-            <VocalImageFrame onMouseEnter={setHover} onMouseLeave={setHover}>
+            <VocalImageFrame
+              onMouseEnter={(e) => setHover(e, vocalUploadImg, setIsHover)}
+              onMouseLeave={(e) => setHover(e, vocalUploadImg, setIsHover)}>
               <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
                 <VocalUploadImage src={vocalUploadImg} alt="썸네일이미지" isHover={isHover} />
               </label>
               <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-                {isHover && <FileChangeIcon onMouseEnter={setHover} onMouseLeave={setHover} />}
+                {isHover && (
+                  <FileChangeIcon
+                    onMouseEnter={(e) => setHover(e, vocalUploadImg, setIsHover)}
+                    onMouseLeave={(e) => setHover(e, vocalUploadImg, setIsHover)}
+                  />
+                )}
               </label>
             </VocalImageFrame>
           </VocalImageBox>
@@ -60,7 +56,7 @@ export default function VocalUpload(props: propsType) {
             id="imageFileUpload"
             style={{ display: "none" }}
             accept=".jpg,.jpeg,.png"
-            onChange={uploadImageFile}
+            onChange={(e) => uploadImage(e, setVocalUploadImg, setUploadData)}
             readOnly
           />
 

--- a/src/@components/upload/vocalUpload.tsx
+++ b/src/@components/upload/vocalUpload.tsx
@@ -6,11 +6,12 @@ import { useRecoilState } from "recoil";
 import VocalUploadDefaultImg from "../../assets/image/vocalUploadDefaultImg.png";
 import VocalUploadFrameIc from "../../assets/icon/vocalUploadFrameIc.svg";
 import { FileChangeIc } from "../../assets";
+import { uploadImage } from "../../utils/uploadPage/uploadImage";
 
 export default function VocalUpload() {
   const [vocalUploadImg, setVocalUploadImg] = useState<string>(VocalUploadDefaultImg);
   const [vocalJacketImage, setVocalJacketImage] = useRecoilState<File | Blob>(uploadVocalJacketImage);
-  const [defaultstate, setDefaultState] = useRecoilState<boolean>(defaultImageState);
+  const [defaultState, setDefaultState] = useRecoilState<boolean>(defaultImageState);
   const [isHover, setIsHover] = useState<boolean>(false);
 
   function setHover(e: React.MouseEvent<HTMLDivElement | SVGSVGElement>) {
@@ -19,49 +20,9 @@ export default function VocalUpload() {
     }
   }
 
-  function uploadImage(e: React.ChangeEvent<HTMLInputElement>) {
-    if (e.target.value.length === 0) {
-      if (vocalUploadImg === VocalUploadDefaultImg) {
-        setVocalUploadImg(VocalUploadDefaultImg);
-      } else {
-        return;
-      }
-    }
-
-    if (e.target.files !== null) {
-      const fileUrl = URL.createObjectURL(e.target.files[0]);
-      const imageSize = e.target.files[0].size;
-      if (checImageSize(imageSize)) {
-        setVocalUploadImg(fileUrl);
-        setVocalJacketImage(e.target.files[0]);
-        setDefaultState(false);
-      }
-    }
+  function uploadImageFile(e: React.ChangeEvent<HTMLInputElement>) {
+    uploadImage(e, setVocalUploadImg, setVocalJacketImage, setDefaultState);
   }
-
-  function checImageSize(imageSize: number) : boolean {
-    if (imageSize > 5 * 1024 * 1024) {
-      alert("이미지 용량제한은 5MB 이하 입니다.");
-      return false;
-    } else {
-      return true;
-    }
-  }
-
-  async function convertURLtoFile(url: string) {
-    const response = await fetch(url);
-    const data = await response.blob();
-    const ext = url.split(".").pop(); // url 구조에 맞게 수정할 것
-    const filename = url.split("/").pop(); // url 구조에 맞게 수정할 것
-    const metadata = { type: `image/${ext}` };
-    return new File([data], filename!, metadata);
-  }
-
-  useEffect(() => {
-    convertURLtoFile("../assets/image/vocalUploadDefaultImg.png").then((data) => {
-      setVocalJacketImage(data);
-    });
-  }, []);
 
   return (
     <Container>
@@ -81,7 +42,7 @@ export default function VocalUpload() {
           id="imageFileUpload"
           style={{ display: "none" }}
           accept=".jpg,.jpeg,.png"
-          onChange={uploadImage}
+          onChange={uploadImageFile}
           readOnly
         />
 

--- a/src/@components/upload/vocalUpload.tsx
+++ b/src/@components/upload/vocalUpload.tsx
@@ -6,64 +6,51 @@ import VocalUploadFrameIc from "../../assets/icon/vocalUploadFrameIc.svg";
 import { FileChangeIc } from "../../assets";
 import { uploadImage, setHover } from "../../utils/uploadPage/uploadImage";
 import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
-import UploadHeader from "../@common/uploadHeader";
 
 interface propsType {
-  userType: string;
-  producerUploadType: string | undefined;
   uploadData: UploadInfoDataType;
-  uploadDataRef: UploadInfoRefType;
   setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
   setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
 }
 
 export default function VocalUpload(props: propsType) {
-  const { userType, producerUploadType, uploadData, uploadDataRef, setUploadData, setUploadDataRef } = props;
+  const { uploadData, setUploadData, setUploadDataRef } = props;
 
   const [vocalUploadImg, setVocalUploadImg] = useState<string>(VocalUploadDefaultImg);
   const [isHover, setIsHover] = useState<boolean>(false);
 
   return (
-    <>
-      <UploadHeader
-        userType={userType}
-        producerUploadType={producerUploadType}
-        uploadData={uploadData}
-        setUploadData={setUploadData}
-        uploadDataRef={uploadDataRef}
-      />
-      <Container>
-        <SectionWrapper>
-          <VocalImageBox>
-            <VocalImageFrame
-              onMouseEnter={(e) => setHover(e, vocalUploadImg, setIsHover)}
-              onMouseLeave={(e) => setHover(e, vocalUploadImg, setIsHover)}>
-              <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-                <VocalUploadImage src={vocalUploadImg} alt="썸네일이미지" isHover={isHover} />
-              </label>
-              <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-                {isHover && (
-                  <FileChangeIcon
-                    onMouseEnter={(e) => setHover(e, vocalUploadImg, setIsHover)}
-                    onMouseLeave={(e) => setHover(e, vocalUploadImg, setIsHover)}
-                  />
-                )}
-              </label>
-            </VocalImageFrame>
-          </VocalImageBox>
-          <input
-            type="file"
-            id="imageFileUpload"
-            style={{ display: "none" }}
-            accept=".jpg,.jpeg,.png"
-            onChange={(e) => uploadImage(e, setVocalUploadImg, setUploadData)}
-            readOnly
-          />
+    <Container>
+      <SectionWrapper>
+        <VocalImageBox>
+          <VocalImageFrame
+            onMouseEnter={(e) => setHover(e, vocalUploadImg, setIsHover)}
+            onMouseLeave={(e) => setHover(e, vocalUploadImg, setIsHover)}>
+            <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
+              <VocalUploadImage src={vocalUploadImg} alt="썸네일이미지" isHover={isHover} />
+            </label>
+            <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
+              {isHover && (
+                <FileChangeIcon
+                  onMouseEnter={(e) => setHover(e, vocalUploadImg, setIsHover)}
+                  onMouseLeave={(e) => setHover(e, vocalUploadImg, setIsHover)}
+                />
+              )}
+            </label>
+          </VocalImageFrame>
+        </VocalImageBox>
+        <input
+          type="file"
+          id="imageFileUpload"
+          style={{ display: "none" }}
+          accept=".jpg,.jpeg,.png"
+          onChange={(e) => uploadImage(e, setVocalUploadImg, setUploadData)}
+          readOnly
+        />
 
-          <UploadInfo uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
-        </SectionWrapper>
-      </Container>
-    </>
+        <UploadInfo uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
+      </SectionWrapper>
+    </Container>
   );
 }
 

--- a/src/@components/upload/vocalUpload.tsx
+++ b/src/@components/upload/vocalUpload.tsx
@@ -1,54 +1,73 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import styled, { css } from "styled-components";
 import UploadInfo from "../@common/uploadInfo";
-import { uploadVocalJacketImage, defaultImageState } from "../../recoil/upload";
-import { useRecoilState } from "recoil";
 import VocalUploadDefaultImg from "../../assets/image/vocalUploadDefaultImg.png";
 import VocalUploadFrameIc from "../../assets/icon/vocalUploadFrameIc.svg";
 import { FileChangeIc } from "../../assets";
-import { uploadImage } from "../../utils/uploadPage/uploadImage";
+import { uploadImage, isDefaultImage } from "../../utils/uploadPage/uploadImage";
+import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
+import { isMouseEnter } from "../../utils/common/eventType";
+import UploadHeader from "../@common/uploadHeader";
 
-export default function VocalUpload() {
+interface propsType {
+  userType: string;
+  producerUploadType: string | undefined;
+  uploadData: UploadInfoDataType;
+  uploadDataRef: UploadInfoRefType;
+  setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
+  setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
+}
+
+export default function VocalUpload(props: propsType) {
+  const { userType, producerUploadType, uploadData, uploadDataRef, setUploadData, setUploadDataRef } = props;
+
   const [vocalUploadImg, setVocalUploadImg] = useState<string>(VocalUploadDefaultImg);
-  const [vocalJacketImage, setVocalJacketImage] = useRecoilState<File | Blob>(uploadVocalJacketImage);
-  const [defaultState, setDefaultState] = useRecoilState<boolean>(defaultImageState);
   const [isHover, setIsHover] = useState<boolean>(false);
 
   function setHover(e: React.MouseEvent<HTMLDivElement | SVGSVGElement>) {
-    if (vocalUploadImg !== VocalUploadDefaultImg) {
-      e.type === "mouseenter" ? setIsHover(true) : setIsHover(false);
+    if (!isDefaultImage(vocalUploadImg)) {
+      isMouseEnter(e) ? setIsHover(true) : setIsHover(false);
     }
   }
 
   function uploadImageFile(e: React.ChangeEvent<HTMLInputElement>) {
-    // uploadImage(e, setVocalUploadImg, setVocalJacketImage, setDefaultState);
+    uploadImage(e, setVocalUploadImg, setUploadData);
   }
 
   return (
-    <Container>
-      <SectionWrapper>
-        <VocalImageBox>
-          <VocalImageFrame onMouseEnter={setHover} onMouseLeave={setHover}>
-            <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-              <VocalUploadImage src={vocalUploadImg} alt="썸네일이미지" isHover={isHover} />
-            </label>
-            <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-              {isHover && <FileChangeIcon onMouseEnter={setHover} onMouseLeave={setHover} />}
-            </label>
-          </VocalImageFrame>
-        </VocalImageBox>
-        <input
-          type="file"
-          id="imageFileUpload"
-          style={{ display: "none" }}
-          accept=".jpg,.jpeg,.png"
-          onChange={uploadImageFile}
-          readOnly
-        />
+    <>
+      <UploadHeader
+        userType={userType}
+        producerUploadType={producerUploadType}
+        uploadData={uploadData}
+        setUploadData={setUploadData}
+        uploadDataRef={uploadDataRef}
+      />
+      <Container>
+        <SectionWrapper>
+          <VocalImageBox>
+            <VocalImageFrame onMouseEnter={setHover} onMouseLeave={setHover}>
+              <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
+                <VocalUploadImage src={vocalUploadImg} alt="썸네일이미지" isHover={isHover} />
+              </label>
+              <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
+                {isHover && <FileChangeIcon onMouseEnter={setHover} onMouseLeave={setHover} />}
+              </label>
+            </VocalImageFrame>
+          </VocalImageBox>
+          <input
+            type="file"
+            id="imageFileUpload"
+            style={{ display: "none" }}
+            accept=".jpg,.jpeg,.png"
+            onChange={uploadImageFile}
+            readOnly
+          />
 
-        {/* <UploadInfo /> */}
-      </SectionWrapper>
-    </Container>
+          <UploadInfo uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
+        </SectionWrapper>
+      </Container>
+    </>
   );
 }
 

--- a/src/@pages/uploadPage.tsx
+++ b/src/@pages/uploadPage.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import TrackUploadDefaultImg from "../assets/image/trackUploadDefaultImg.png";
 import VocalUploadDefaultImg from "../assets/image/vocalUploadDefaultImg.png";
 import { isMaker } from "../utils/common/userType";
+import UploadHeader from "../@components/@common/uploadHeader";
 
 export default function UploadPage() {
   const userType = useRecoilValue(UserType);
@@ -37,24 +38,17 @@ export default function UploadPage() {
 
   return (
     <>
+      <UploadHeader
+        userType={userType}
+        producerUploadType={producerUploadType}
+        uploadData={uploadData}
+        setUploadData={setUploadData}
+        uploadDataRef={uploadDataRef}
+      />
       {isMaker(userType) ? (
-        <TrackUpload
-          userType={userType}
-          producerUploadType={producerUploadType}
-          uploadData={uploadData}
-          uploadDataRef={uploadDataRef}
-          setUploadData={setUploadData}
-          setUploadDataRef={setUploadDataRef}
-        />
+        <TrackUpload uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
       ) : (
-        <VocalUpload
-          userType={userType}
-          producerUploadType={producerUploadType}
-          uploadData={uploadData}
-          uploadDataRef={uploadDataRef}
-          setUploadData={setUploadData}
-          setUploadDataRef={setUploadDataRef}
-        />
+        <VocalUpload uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
       )}
     </>
   );

--- a/src/@pages/uploadPage.tsx
+++ b/src/@pages/uploadPage.tsx
@@ -7,10 +7,12 @@ import { UploadInfoDataType, UploadInfoRefType } from "../type/uploadInfoDataTyp
 import { useState } from "react";
 import TrackUploadDefaultImg from "../assets/image/trackUploadDefaultImg.png";
 import VocalUploadDefaultImg from "../assets/image/vocalUploadDefaultImg.png";
+import { isMaker } from "../utils/common/userType";
 
 export default function UploadPage() {
   const userType = useRecoilValue(UserType);
   const { producerUploadType } = useParams();
+
   const [uploadData, setUploadData] = useState<UploadInfoDataType>({
     title: "",
     category: "Select",
@@ -24,14 +26,9 @@ export default function UploadPage() {
     introduceRef: null,
   });
 
-  function checkUserType(userType: string): boolean {
-    return userType === "producer";
-  }
-
   function getDefaultImage(): FormData {
     let defaultImage = new FormData();
-
-    checkUserType(userType)
+    isMaker(userType)
       ? defaultImage.append("defaultImage", TrackUploadDefaultImg)
       : defaultImage.append("defaultImage", VocalUploadDefaultImg);
 
@@ -40,8 +37,7 @@ export default function UploadPage() {
 
   return (
     <>
-      {/* <UploadHeader userType={userType} producerUploadType={producerUploadType} /> */}
-      {userType === "producer" ? (
+      {isMaker(userType) ? (
         <TrackUpload
           userType={userType}
           producerUploadType={producerUploadType}

--- a/src/@pages/uploadPage.tsx
+++ b/src/@pages/uploadPage.tsx
@@ -1,19 +1,58 @@
-import UploadHeader from "../@components/@common/uploadHeader";
 import TrackUpload from "../@components/upload/trackUpload";
 import VocalUpload from "../@components/upload/vocalUpload";
 import { useRecoilValue } from "recoil";
 import { UserType } from "../recoil/main";
 import { useParams } from "react-router-dom";
+import { UploadInfoDataType, UploadInfoRefType } from "../type/uploadInfoDataType";
+import { useState } from "react";
+import TrackUploadDefaultImg from "../assets/image/trackUploadDefaultImg.png";
+import VocalUploadDefaultImg from "../assets/image/vocalUploadDefaultImg.png";
 
 export default function UploadPage() {
   const userType = useRecoilValue(UserType);
-  const {producerUploadType}=useParams();
+  const { producerUploadType } = useParams();
+  const [uploadData, setUploadData] = useState<UploadInfoDataType>({
+    title: "",
+    category: "Select",
+    wavFile: null,
+    introduce: "",
+    keyword: [],
+    jacketImage: getDefaultImage(),
+  });
 
+  const [uploadDataRef, setUploadDataRef] = useState<UploadInfoRefType>({
+    introduceRef: null,
+  });
+
+  function checkUserType(userType: string): boolean {
+    return userType === "producer";
+  }
+
+  function getDefaultImage(): FormData {
+    let defaultImage = new FormData();
+
+    checkUserType(userType)
+      ? defaultImage.append("defaultImage", TrackUploadDefaultImg)
+      : defaultImage.append("defaultImage", VocalUploadDefaultImg);
+
+    return defaultImage;
+  }
 
   return (
     <>
-      <UploadHeader userType={userType} producerUploadType={producerUploadType} />
-      {userType === "producer" ? <TrackUpload /> : <VocalUpload />}
+      {/* <UploadHeader userType={userType} producerUploadType={producerUploadType} /> */}
+      {userType === "producer" ? (
+        <TrackUpload
+          userType={userType}
+          producerUploadType={producerUploadType}
+          uploadData={uploadData}
+          uploadDataRef={uploadDataRef}
+          setUploadData={setUploadData}
+          setUploadDataRef={setUploadDataRef}
+        />
+      ) : (
+        <VocalUpload />
+      )}
     </>
   );
 }

--- a/src/@pages/uploadPage.tsx
+++ b/src/@pages/uploadPage.tsx
@@ -51,7 +51,14 @@ export default function UploadPage() {
           setUploadDataRef={setUploadDataRef}
         />
       ) : (
-        <VocalUpload />
+        <VocalUpload
+          userType={userType}
+          producerUploadType={producerUploadType}
+          uploadData={uploadData}
+          uploadDataRef={uploadDataRef}
+          setUploadData={setUploadData}
+          setUploadDataRef={setUploadDataRef}
+        />
       )}
     </>
   );

--- a/src/core/api/upload.ts
+++ b/src/core/api/upload.ts
@@ -24,6 +24,6 @@ export async function UploadInfo(postData: Object, userType: string, producerUpl
         break;
     }
   } catch (error) {
-    alert('업로드 실패');
+    alert("업로드 실패");
   }
 }

--- a/src/core/constants/fileSize.ts
+++ b/src/core/constants/fileSize.ts
@@ -1,0 +1,3 @@
+export enum fileSize {
+  LIMIT_IMAGE_SIZE = 5 * 1024 * 1024,
+}

--- a/src/type/uploadInfoDataType.ts
+++ b/src/type/uploadInfoDataType.ts
@@ -2,9 +2,9 @@ export interface UploadInfoDataType {
   title: string;
   category: string;
   wavFile: File | null;
-  introduce: string;
+  introduce: string | undefined;
   keyword: Array<string>;
-  jacketImage: File | Blob | FormData | null;
+  jacketImage: File | Blob | FormData;
 }
 
 export interface UploadInfoRefType {

--- a/src/type/uploadInfoDataType.ts
+++ b/src/type/uploadInfoDataType.ts
@@ -1,0 +1,8 @@
+export interface UploadInfoDataType {
+  title: string;
+  category: string;
+  wavFile: File | null;
+  introduce: string;
+  keyword: string[];
+  jacketImage: File | Blob | FormData | null;
+}

--- a/src/type/uploadInfoDataType.ts
+++ b/src/type/uploadInfoDataType.ts
@@ -3,6 +3,10 @@ export interface UploadInfoDataType {
   category: string;
   wavFile: File | null;
   introduce: string;
-  keyword: string[];
+  keyword: Array<string>;
   jacketImage: File | Blob | FormData | null;
+}
+
+export interface UploadInfoRefType {
+  introduceRef: React.MutableRefObject<HTMLTextAreaElement | null> | null;
 }

--- a/src/utils/common/eventType.ts
+++ b/src/utils/common/eventType.ts
@@ -3,7 +3,7 @@ export function isEnterKey(e: React.KeyboardEvent): boolean {
 }
 
 export function isMouseEnter(e: React.MouseEvent): boolean {
-  return e.type === "mouseentter";
+  return e.type === "mouseenter";
 }
 
 export function isFocus(e: React.FocusEvent): boolean {

--- a/src/utils/common/eventType.ts
+++ b/src/utils/common/eventType.ts
@@ -1,0 +1,11 @@
+export function isEnterKey(e: React.KeyboardEvent): boolean {
+  return e.key === "Enter";
+}
+
+export function isMouseEnter(e: React.MouseEvent): boolean {
+  return e.type === "mouseentter";
+}
+
+export function isFocus(e: React.FocusEvent): boolean {
+  return e.type === "focus";
+}

--- a/src/utils/common/userType.ts
+++ b/src/utils/common/userType.ts
@@ -1,0 +1,5 @@
+import { currentUser } from "../../core/constants/userType";
+
+export function isMaker(userType: string): boolean {
+  return userType === currentUser.PRODUCER;
+}

--- a/src/utils/uploadPage/maxLength.ts
+++ b/src/utils/uploadPage/maxLength.ts
@@ -1,3 +1,3 @@
 export function checkMaxInputLength(length: number, limit: number) : boolean {
-  return length < limit;
+  return length <= limit;
 }

--- a/src/utils/uploadPage/maxLength.ts
+++ b/src/utils/uploadPage/maxLength.ts
@@ -1,0 +1,3 @@
+export function checkMaxInputLength(length: number, limit: number) : boolean {
+  return length < limit;
+}

--- a/src/utils/uploadPage/uploadImage.ts
+++ b/src/utils/uploadPage/uploadImage.ts
@@ -2,6 +2,7 @@ import { fileSize } from "../../core/constants/fileSize";
 import TrackUploadDefaultImg from "../../assets/image/trackUploadDefaultImg.png";
 import VocalUploadDefaultImg from "../../assets/image/vocalUploadDefaultImg.png";
 import { UploadInfoDataType } from "../../type/uploadInfoDataType";
+import { isMouseEnter } from "../../utils/common/eventType";
 
 export function uploadImage(
   e: React.ChangeEvent<HTMLInputElement>,
@@ -19,6 +20,16 @@ export function uploadImage(
         return { ...prevState, jacketImage: file };
       });
     }
+  }
+}
+
+export function setHover(
+  e: React.MouseEvent<HTMLDivElement | SVGSVGElement>,
+  defaultImage: string,
+  setIsHover: React.Dispatch<React.SetStateAction<boolean>>,
+) {
+  if (!isDefaultImage(defaultImage)) {
+    isMouseEnter(e) ? setIsHover(true) : setIsHover(false);
   }
 }
 

--- a/src/utils/uploadPage/uploadImage.ts
+++ b/src/utils/uploadPage/uploadImage.ts
@@ -1,12 +1,12 @@
 import { fileSize } from "../../core/constants/fileSize";
 import TrackUploadDefaultImg from "../../assets/image/trackUploadDefaultImg.png";
 import VocalUploadDefaultImg from "../../assets/image/vocalUploadDefaultImg.png";
+import { UploadInfoDataType } from "../../type/uploadInfoDataType";
 
 export function uploadImage(
   e: React.ChangeEvent<HTMLInputElement>,
   setUploadImg: React.Dispatch<React.SetStateAction<string>>,
-  setJacketImage: React.Dispatch<React.SetStateAction<File | Blob>>,
-  setDefaultState: React.Dispatch<React.SetStateAction<boolean>>,
+  setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>,
 ): void {
   const uploadName = e.target.value.substring(e.target.value.lastIndexOf("\\") + 1);
   if (checkImageType(uploadName) && e.target.files) {
@@ -15,8 +15,9 @@ export function uploadImage(
     const imageSize: number = getFileSize(file);
     if (checkImageSize(imageSize)) {
       setUploadImg(fileUrl);
-      setJacketImage(e.target.files[0]);
-      setDefaultState(false);
+      setUploadData((prevState) => {
+        return { ...prevState, jacketImage: file };
+      });
     }
   }
 }

--- a/src/utils/uploadPage/uploadImage.ts
+++ b/src/utils/uploadPage/uploadImage.ts
@@ -1,0 +1,49 @@
+import { fileSize } from "../../core/constants/fileSize";
+import TrackUploadDefaultImg from "../../assets/image/trackUploadDefaultImg.png";
+import VocalUploadDefaultImg from "../../assets/image/vocalUploadDefaultImg.png";
+
+export function uploadImage(
+  e: React.ChangeEvent<HTMLInputElement>,
+  setUploadImg: React.Dispatch<React.SetStateAction<string>>,
+  setJacketImage: React.Dispatch<React.SetStateAction<File | Blob>>,
+  setDefaultState: React.Dispatch<React.SetStateAction<boolean>>,
+): void {
+  const uploadName = e.target.value.substring(e.target.value.lastIndexOf("\\") + 1);
+  if (checkImageType(uploadName) && e.target.files) {
+    const file = e.target.files[0];
+    const fileUrl: string = getFileURL(file);
+    const imageSize: number = getFileSize(file);
+    if (checkImageSize(imageSize)) {
+      setUploadImg(fileUrl);
+      setJacketImage(e.target.files[0]);
+      setDefaultState(false);
+    }
+  }
+}
+
+export function isDefaultImage(image: string): boolean {
+  return image !== (TrackUploadDefaultImg || VocalUploadDefaultImg);
+}
+
+function getFileURL(file: File): string {
+  return URL.createObjectURL(file);
+}
+
+function getFileSize(file: File): number {
+  return file.size;
+}
+
+function getImageType(uploadName: string): string {
+  return uploadName.substring(uploadName.length - 4);
+}
+
+function checkImageSize(imageSize: number): boolean {
+  if (imageSize > fileSize.LIMIT_IMAGE_SIZE) alert("파일용량 제한은 5MB 입니다.");
+  return imageSize < fileSize.LIMIT_IMAGE_SIZE;
+}
+
+function checkImageType(uploadName: string): boolean {
+  const fileType = getImageType(uploadName);
+  !(fileType === ".jpg" || fileType === "jpeg" || fileType === ".png") && alert("확장자명을 확인해 주세요.");
+  return fileType === ".jpg" || fileType === "jpeg" || fileType === ".png";
+}

--- a/src/utils/uploadPage/uploadImage.ts
+++ b/src/utils/uploadPage/uploadImage.ts
@@ -23,7 +23,7 @@ export function uploadImage(
 }
 
 export function isDefaultImage(image: string): boolean {
-  return image !== (TrackUploadDefaultImg || VocalUploadDefaultImg);
+  return image === TrackUploadDefaultImg || image === VocalUploadDefaultImg;
 }
 
 function getFileURL(file: File): string {


### PR DESCRIPTION
### ✅ 구현기능 명세
- [x] 전역변수를 props 로 전달하여 진행.
- [x] 코드 리팩토링, 클린코드

### 📝 이렇게 구현해봣어요
1. uploadPage
- 전역변수를 지우고 uploadData, uploadDataRef 변수를 선언해주고 props로 전달해줬어요!
- uploadHeader에서 상태에 따라서 업로드 버튼이 달라지기 때문에 introduce(소개글)을 제외한 나머지 변수는 state로 하기로 했어요!


2. uploadHeader
- upload 버튼을 눌렀을 때에 introduceRef의 현재값을 할당해주어서 업로드 해주도록 변경했어요.
- useEffect를 통해 uploadData가 조건을 충족했을 경우 업로드 버튼일 바뀌게 해줬어요!

3. vocalUpload,trackUpload
- 이미지를 업로드하는 부분은 아예 똑같기 때문에 util 함수(util/uploadPage/uploadImage.ts)로 빼고 다르게 변경해줘야하는건 인자로 받아서 변경할 수 있도록 했어요.

4. uploadInfo
- 함수로 뺄 수 있는것들은 모조리 빼서 진행했고 재사용할 수 있는것들을 많이 빼서 진행해봤어요!

### 🙌🏻 같이 고민했으면 하는 부분
1. BackPage를 커스텀 훅으로 빼서 진행해보려했는데 졸려서 못했어요..!! 앞으로 계속해서 사용하는거라 빼서 진행해야할거 같아요!

2. 예를들어 이 함수를 2번밖에 사용안하는데 굳이 util로 빼야할까? 라는 생각이 진짜 많이 들긴했어요. 어디서부터 util로 빼야 재사용성의 장점을 살릴 수 있을지 같이 고민해봤으면 좋을거 같아요!