### PR TITLE
Release1.0#165 track post/refactor

### DIFF
--- a/src/@components/@common/player.tsx
+++ b/src/@components/@common/player.tsx
@@ -20,7 +20,6 @@ interface PropsType {
 }
 
 export default function Player(props: any) {
-  // const { audio, playAudio, pauseAudio, progress, duration, title, name, image, play, setPlay } = props;
   const { audio, playAudio, pauseAudio, progress, play, setPlay, audioInfos } = props;
   const tracksOrVocals = useRecoilValue(tracksOrVocalsCheck);
 

--- a/src/@components/trackPost/commentHeader.tsx
+++ b/src/@components/trackPost/commentHeader.tsx
@@ -1,8 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
-import { ToggleIc, Track1Ic } from "../../assets";
-import profileImg from "../../assets/image/profileImg.png";
+import { Track1Ic } from "../../assets";
 
 export default function CommentHeader() {
   const navigate = useNavigate();
@@ -23,7 +22,6 @@ export default function CommentHeader() {
 }
 
 const CategoryHeaderContainer = styled.header`
-  /* position: sticky; */
   top: 0;
 
   width: 192rem;

--- a/src/@components/trackPost/eachUserComment.tsx
+++ b/src/@components/trackPost/eachUserComment.tsx
@@ -6,53 +6,57 @@ import { useRecoilState } from "recoil";
 import { showPlayerBar, playMusic } from "../../recoil/player";
 
 interface PropsType {
-  data: UserCommentType;
+  commentInfo: UserCommentType;
   audio: HTMLAudioElement;
   clickedIndex: number;
   pauseAudio: () => void;
   clickComment: (index: number) => void;
-  index: number;
+  currentIndex: number;
 }
 
 export default function EachUserComment(props: PropsType) {
-  const { data, audio, clickedIndex, clickComment, index, pauseAudio } = props;
+  const { commentInfo, audio, clickedIndex, clickComment, currentIndex, pauseAudio } = props;
 
   const [isHover, setIsHover] = useState<boolean>(false);
 
   const [showPlayer, setShowPlayer] = useRecoilState<boolean>(showPlayerBar);
   const [play, setPlay] = useRecoilState<boolean>(playMusic);
 
-  function changeHoverTrue() {
+  function hoverComment() {
     setIsHover(true);
   }
 
-  function changeHoverFalse() {
+  function detachComment() {
     setIsHover(false);
   }
 
-  function playAudioOnTrack(id: number) {
+  function checkIsPlayingAudioClicked() {
+    return clickedIndex === currentIndex;
+  }
+
+  function playAudio(id: number) {
     setShowPlayer(true);
     setPlay(true);
-    clickedIndex === id ? audio.play() : clickComment(index);
+    clickedIndex === id ? audio.play() : clickComment(currentIndex);
   }
 
   return (
-    <CommentContainer onMouseOver={changeHoverTrue} onMouseOut={changeHoverFalse}>
-      <ProfileImage img={data.vocalProfileImage}>
-        {isHover && (!play || clickedIndex !== index) && (
-          <PlayerBlur onClick={() => playAudioOnTrack(index)}>
+    <CommentContainer onMouseOver={hoverComment} onMouseOut={detachComment}>
+      <ProfileImage img={commentInfo.vocalProfileImage}>
+        {isHover && !(play && checkIsPlayingAudioClicked()) && (
+          <PlayerBlur onClick={() => playAudio(currentIndex)}>
             <PlayBtnIc />
           </PlayerBlur>
         )}
-        {play && clickedIndex === index && (
+        {play && checkIsPlayingAudioClicked() && (
           <PlayerBlur onClick={pauseAudio}>
             <PauseBtnIc />
           </PlayerBlur>
         )}
       </ProfileImage>
       <InfoBox>
-        <UserName>{data.vocalName}</UserName>
-        <CommentText>{data.comment}</CommentText>
+        <UserName>{commentInfo.vocalName}</UserName>
+        <CommentText>{commentInfo.comment}</CommentText>
       </InfoBox>
     </CommentContainer>
   );

--- a/src/@components/trackPost/userComment.tsx
+++ b/src/@components/trackPost/userComment.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { AddCommentIc, CloseBtnIc, CommentBtnIc } from "../../assets";
 import CommentWrite from "./commentWrite";
-import EachUseComment from "./eachUserComment";
+import EachUserComment from "./eachUserComment";
 import { useEffect, useState, useMemo } from "react";
 import { UploadDataType } from "../../type/uploadDataType";
 
@@ -24,7 +24,6 @@ export default function UserComment(props: PropsType) {
 
   const [comments, setComments] = useState<UserCommentType[]>();
   const [progress, setProgress] = useState<number>(0);
-  const [duration, setDuration] = useState<number>(0);
   const [clickedIndex, setClickedIndex] = useState<number>(-1);
   const [currentAudioFile, setCurrentAudioFile] = useState<string>("");
   const [uploadData, setUploadData] = useState<UploadDataType>({
@@ -52,7 +51,6 @@ export default function UserComment(props: PropsType) {
     if (comments) {
       audio.src = comments[clickedIndex].vocalWavFile;
       setCurrentAudioFile(comments[clickedIndex].vocalWavFile);
-      setDuration(comments[clickedIndex].vocalWavFileLength);
       getAudioInfos(
         "title",
         comments[clickedIndex]?.vocalName,
@@ -178,16 +176,16 @@ export default function UserComment(props: PropsType) {
           {comments &&
             comments.map((data, index) => {
               return (
-                <EachUseComment
+                <EachUserComment
                   key={index}
-                  data={comments[index]}
+                  commentInfo={data}
                   audio={audio}
                   clickedIndex={clickedIndex}
                   clickComment={clickComment}
                   pauseAudio={pauseAudio}
-                  index={index}
+                  currentIndex={index}
                 />
-              ); //여기가 각각의 데이터
+              );
             })}
           <BlurSection />
         </CommentWriteWrapper>

--- a/src/@pages/trackPostPage.tsx
+++ b/src/@pages/trackPostPage.tsx
@@ -209,10 +209,6 @@ export default function TrackPostPage() {
             playAudio={playAudio}
             pauseAudio={pauseAudio}
             progress={progress}
-            // duration={duration}
-            // title={trackInfoData?.title}
-            // name={trackInfoData?.producerName}
-            // image={image}
             audioInfos={audioInfos}
             play={play}
             setPlay={setPlay}

--- a/src/type/audioTypes.ts
+++ b/src/type/audioTypes.ts
@@ -3,3 +3,11 @@ export interface AudioTypes {
   progress: number;
   isPlay: boolean;
 }
+
+export interface AudioInfosType {
+  title: string;
+  name: string;
+  progress: number;
+  duration: number;
+  image: string;
+}

--- a/src/utils/hooks/usePlayerInfos.ts
+++ b/src/utils/hooks/usePlayerInfos.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { AudioInfosType } from "../../type/audioTypes";
+
+export default function usePlayerInfos(dependency: any, infoDatas: any) {
+  const [audioInfos, setAudioInfos] = useState<AudioInfosType>({
+    title: "",
+    name: "",
+    progress: 0,
+    duration: 0,
+    image: "",
+  });
+
+  function getAudioInfos(title: string, name: string, image: string, duration: number) {
+    const tempInfos = audioInfos;
+    tempInfos.title = title;
+    tempInfos.name = name;
+    tempInfos.image = image;
+    tempInfos.duration = duration;
+
+    setAudioInfos(tempInfos);
+  }
+
+  useEffect(() => {
+    getAudioInfos(infoDatas?.title, infoDatas?.producerName, infoDatas?.jacketImage, infoDatas?.wavFileLength);
+  }, [dependency]);
+
+  return { audioInfos };
+}


### PR DESCRIPTION
### ✅ 구현기능 명세
- trackPostPage 에 관련된 모든 컴포넌트의 리팩토링 진행했습니다.
- 플레이어에 제목과같은 info정보들을 전달해주는 커스텀훅을 생성했어요. (다른 페이지에서 쓰일 것 같아요.)

### 📝 이렇게 구현해봣어요
```
export default function usePlayerInfos(dependency: any, infoDatas: any) {
  const [audioInfos, setAudioInfos] = useState<AudioInfosType>({
    title: "",
    name: "",
    progress: 0,
    duration: 0,
    image: "",
  });

  function getAudioInfos(title: string, name: string, image: string, duration: number) {
    const tempInfos = audioInfos;
    tempInfos.title = title;
    tempInfos.name = name;
    tempInfos.image = image;
    tempInfos.duration = duration;

    setAudioInfos(tempInfos);
  }

  useEffect(() => {
    getAudioInfos(infoDatas?.title, infoDatas?.producerName, infoDatas?.jacketImage, infoDatas?.wavFileLength);
  }, [dependency]);

  return { audioInfos };
}
```
--> infos에 관한 state를 훅 안에서 선언하고 return 을 해줬어요!
각 컴포넌트에서는 리턴된 audioInfo를 사용해서 player에 프롭스로 내려줄꺼에요.

### 🙌🏻 같이 고민했으면 하는 부분
플레이어 관련 로직이, trackPost랑 comment 부분이 완전히 독립적으로 달라서 커스텀훅으로 빼는데 무리가 있었어요.. 
그래서 그냥 플레이어를 따로 선언했어요. 이부분이 아직까지도 고민이네요...
