### PR TITLE
Release1.0#173 upload page/refactor

### DIFF
--- a/src/@components/@common/uploadHeader.tsx
+++ b/src/@components/@common/uploadHeader.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 import { useMutation } from "react-query";
 import { uploadButtonClickedInTrackList } from "../../recoil/uploadButtonClicked";
 import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
-import { isMaker } from "../../utils/common/userType";
+import { checkUserType } from "../../utils/common/userType";
 
 interface PropsType {
   userType: string;
@@ -27,7 +27,7 @@ export default function UploadHeader(props: PropsType) {
 
   const { mutate } = useMutation(post, {
     onSuccess: () => {
-      isMaker(userType) ? navigate(-1) : navigate("/vocal-profile/1");
+      checkUserType(userType) ? navigate(-1) : navigate("/vocal-profile/1");
     },
     onError: (error) => {
       console.log("에러!!", error);

--- a/src/@components/@common/uploadHeader.tsx
+++ b/src/@components/@common/uploadHeader.tsx
@@ -6,7 +6,7 @@ import { useRecoilState } from "recoil";
 import { useEffect, useState } from "react";
 import { useMutation } from "react-query";
 import { uploadButtonClickedInTrackList } from "../../recoil/uploadButtonClicked";
-import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
+import { UploadInfoDataType } from "../../type/uploadInfoDataType";
 import { checkUserType } from "../../utils/common/userType";
 
 interface PropsType {
@@ -14,7 +14,7 @@ interface PropsType {
   producerUploadType: string | undefined;
   uploadData: UploadInfoDataType;
   setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
-  uploadDataRef: UploadInfoRefType;
+  uploadDataRef: React.MutableRefObject<HTMLTextAreaElement | null> | null;
 }
 
 export default function UploadHeader(props: PropsType) {
@@ -44,8 +44,8 @@ export default function UploadHeader(props: PropsType) {
 
   function upload(e: React.MouseEvent<SVGSVGElement>) {
     setOpenModal(false);
-    const introduce = uploadDataRef.introduceRef?.current!.value;
-
+    const introduce = uploadDataRef?.current?.value;
+  
     setUploadData((prevState) => {
       return { ...prevState, introduce: introduce };
     });

--- a/src/@components/@common/uploadHeader.tsx
+++ b/src/@components/@common/uploadHeader.tsx
@@ -44,9 +44,10 @@ export default function UploadHeader(props: PropsType) {
 
   function upload(e: React.MouseEvent<SVGSVGElement>) {
     setOpenModal(false);
+    const introduce = uploadDataRef.introduceRef?.current!.value;
 
     setUploadData((prevState) => {
-      return { ...prevState, introduce: uploadDataRef.introduceRef?.current!.value };
+      return { ...prevState, introduce: introduce };
     });
     if (isUploadActive) {
       mutate();

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -18,12 +18,12 @@ import {
 import { Categories } from "../../core/constants/categories";
 import { checkMaxInputLength } from "../../utils/uploadPage/maxLength";
 import { isEnterKey, isMouseEnter, isFocus } from "../../utils/common/eventType";
-import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
+import { UploadInfoDataType } from "../../type/uploadInfoDataType";
 
 interface propsType {
   uploadData: UploadInfoDataType;
   setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
-  setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
+  setUploadDataRef: React.Dispatch<React.SetStateAction<React.MutableRefObject<HTMLTextAreaElement | null> | null>>;
 }
 
 export default function UploadInfo(props: propsType) {
@@ -81,13 +81,7 @@ export default function UploadInfo(props: propsType) {
   }, [hashtagInputWidth]);
 
   useEffect(() => {
-    setUploadDataRef((prevState) => {
-      return {
-        ...prevState,
-        introduceRef: introduceRef,
-      };
-    });
-
+    setUploadDataRef(introduceRef);
     const initArray = getInitFalseArray();
     initArrayState(initArray);
   }, []);

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -15,6 +15,7 @@ import {
   CheckCategoryIc,
 } from "../../assets";
 
+import { Categories } from "../../core/constants/categories";
 import { checkMaxInputLength } from "../../utils/uploadPage/maxLength";
 import { isEnterKey, isMouseEnter, isFocus } from "../../utils/common/eventType";
 import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
@@ -27,7 +28,6 @@ interface propsType {
 
 export default function UploadInfo(props: propsType) {
   const { uploadData, setUploadData, setUploadDataRef } = props;
-  const CATEGORY: string[] = ["R&B", "Hiphop", "Ballad", "Pop", "Rock", "EDM", "Jazz", "House", "Funk"];
   const HASHTAG_WIDTH: number = 8.827;
 
   const titleRef = useRef<HTMLInputElement>(null);
@@ -477,7 +477,7 @@ export default function UploadInfo(props: propsType) {
       </TextCount>
       <DropMenuBox hiddenDropBox={hiddenDropBox}>
         <DropMenuWrapper>
-          {CATEGORY.map((text: string, index: number) => (
+          {Object.values(Categories).map((text: string, index: number) => (
             <DropMenuItem
               checkState={checkState[index]}
               checkHoverState={checkHoverState[index]}

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -19,6 +19,7 @@ import { Categories } from "../../core/constants/categories";
 import { checkMaxInputLength } from "../../utils/uploadPage/maxLength";
 import { isEnterKey, isMouseEnter, isFocus } from "../../utils/common/eventType";
 import { UploadInfoDataType } from "../../type/uploadInfoDataType";
+import useHover from "../../utils/hooks/useHover";
 
 interface propsType {
   uploadData: UploadInfoDataType;
@@ -57,7 +58,8 @@ export default function UploadInfo(props: propsType) {
   const [titleLength, setTitleLength] = useState<number>(0);
   const [descriptionLength, setDescriptionLength] = useState<number>(0);
 
-  const [warningHoverState, setWarningHoverState] = useState<boolean>(false);
+  // const [warningHoverState, setWarningHoverState] = useState<boolean>(false);
+  const { hoverState, changeHoverState } = useHover();
 
   useEffect(() => {
     if (introduceRef && introduceRef.current) {
@@ -268,9 +270,9 @@ export default function UploadInfo(props: propsType) {
     resetHashtagInputWidth();
   }
 
-  function hoverWarningState(e: React.MouseEvent<HTMLInputElement>) {
-    isMouseEnter(e) ? setWarningHoverState(true) : setWarningHoverState(false);
-  }
+  // function hoverWarningState(e: React.MouseEvent<HTMLInputElement>) {
+  //   isMouseEnter(e) ? setWarningHoverState(true) : setWarningHoverState(false);
+  // }
 
   function isEmptyHashtagInput(): boolean {
     return enteredHashtag.current!.value.length === 0;
@@ -442,8 +444,8 @@ export default function UploadInfo(props: propsType) {
               {hashtagLength > 0 && uploadData.keyword.length < 2 && <AddHashtagIcon onClick={addHashtag} />}
             </InputWrapper>
 
-            <WarningIcon onMouseEnter={hoverWarningState} onMouseLeave={hoverWarningState}>
-              {warningHoverState ? (
+            <WarningIcon onMouseEnter={(e) => changeHoverState(e)} onMouseLeave={(e) => changeHoverState(e)}>
+              {hoverState ? (
                 <>
                   <HoverHashtagWarningIc />
                   <WarningTextWrapper>

--- a/src/@components/@common/uploadInfo.tsx
+++ b/src/@components/@common/uploadInfo.tsx
@@ -37,9 +37,9 @@ export default function UploadInfo(props: propsType) {
   const enteredHashtag = useRef<HTMLInputElement | null>(null);
   const categoryRefs = useRef<HTMLLIElement[] | null[]>([]);
 
-  const [checkState, setCheckState] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
-  const [checkHoverState, setCheckHoverState] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
-  const [checkStateIcon, setCheckStateIcon] = useState<Array<boolean>>(new Array(CATEGORY.length).fill(false));
+  const [checkState, setCheckState] = useState<boolean[]>([]);
+  const [checkHoverState, setCheckHoverState] = useState<boolean[]>([]);
+  const [checkStateIcon, setCheckStateIcon] = useState<boolean[]>([]);
 
   const [hiddenDropBox, setHiddenDropBox] = useState<boolean>(true);
   const [fileName, setFileName] = useState<string>("");
@@ -58,6 +58,53 @@ export default function UploadInfo(props: propsType) {
   const [descriptionLength, setDescriptionLength] = useState<number>(0);
 
   const [warningHoverState, setWarningHoverState] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (introduceRef && introduceRef.current) {
+      introduceRef.current.style.height = 0 + "rem";
+      const scrollHeight = introduceRef.current.scrollHeight;
+      changeIntroduceInputHeight(scrollHeight);
+      setTextareaMargin(scrollHeight);
+    }
+  }, [textareaHeight]);
+
+  useEffect(() => {
+    if (checkMaxInputLength(uploadData.keyword.length, 1) && !isEmptyHashtagInput()) {
+      makeZeroInputWidth(0);
+      const inputWidth = enteredHashtag.current!.scrollWidth;
+      changeHashtagInputWidth(inputWidth);
+      setHashtagInputWidth(inputWidth);
+    } else {
+      makeZeroInputWidth(HASHTAG_WIDTH);
+      setHashtagInputWidth(HASHTAG_WIDTH);
+    }
+  }, [hashtagInputWidth]);
+
+  useEffect(() => {
+    setUploadDataRef((prevState) => {
+      return {
+        ...prevState,
+        introduceRef: introduceRef,
+      };
+    });
+
+    const initArray = getInitFalseArray();
+    initArrayState(initArray);
+  }, []);
+
+  function getInitFalseArray(): boolean[] {
+    const initArray: boolean[] = [];
+    Object.values(Categories).forEach(() => {
+      initArray.push(false);
+    });
+    return initArray;
+  }
+
+  function initArrayState(initArray: boolean[]): void {
+    setCheckState(initArray);
+    setCheckHoverState(initArray);
+    setCheckStateIcon(initArray);
+  }
 
   //타이틀
   function changeTitleText(e: React.ChangeEvent<HTMLInputElement>) {
@@ -137,7 +184,8 @@ export default function UploadInfo(props: propsType) {
 
   // 카테고리
   function selectedCategory(e: React.MouseEvent<HTMLLIElement>, index: number) {
-    const temp = new Array(CATEGORY.length).fill(false);
+    const temp = getInitFalseArray();
+
     temp[index] = true;
     setCheckState([...temp]);
     setCheckStateIcon([...temp]);
@@ -149,7 +197,8 @@ export default function UploadInfo(props: propsType) {
   }
 
   function hoverCategoryMenu(e: React.MouseEvent<HTMLLIElement>, index: number) {
-    const hoverMenu = new Array(CATEGORY.length).fill(false);
+    const hoverMenu = getInitFalseArray();
+
     if (isMouseEnter(e)) {
       hoverMenu[index] = true;
       setCheckHoverState([...hoverMenu]);
@@ -272,37 +321,6 @@ export default function UploadInfo(props: propsType) {
   function changeIntroduceInputHeight(scrollHeight: number): void {
     introduceRef.current!.style.height = scrollHeight / 10 + "rem";
   }
-
-  console.log(uploadData.keyword);
-  useEffect(() => {
-    if (introduceRef && introduceRef.current) {
-      introduceRef.current.style.height = 0 + "rem";
-      const scrollHeight = introduceRef.current.scrollHeight;
-      changeIntroduceInputHeight(scrollHeight);
-      setTextareaMargin(scrollHeight);
-    }
-  }, [textareaHeight]);
-
-  useEffect(() => {
-    if (checkMaxInputLength(uploadData.keyword.length, 1) && !isEmptyHashtagInput()) {
-      makeZeroInputWidth(0);
-      const inputWidth = enteredHashtag.current!.scrollWidth;
-      changeHashtagInputWidth(inputWidth);
-      setHashtagInputWidth(inputWidth);
-    } else {
-      makeZeroInputWidth(HASHTAG_WIDTH);
-      setHashtagInputWidth(HASHTAG_WIDTH);
-    }
-  }, [hashtagInputWidth]);
-
-  useEffect(() => {
-    setUploadDataRef((prevState) => {
-      return {
-        ...prevState,
-        introduceRef: introduceRef,
-      };
-    });
-  }, []);
 
   return (
     <Container>

--- a/src/@components/upload/trackUpload.tsx
+++ b/src/@components/upload/trackUpload.tsx
@@ -5,11 +5,15 @@ import TrackUploadDefaultImg from "../../assets/image/trackUploadDefaultImg.png"
 import { FileChangeIc } from "../../assets";
 import { uploadImage, setHover } from "../../utils/uploadPage/uploadImage";
 import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
+import { uploadImage } from "../../utils/uploadPage/uploadImage";
+import { UploadInfoDataType } from "../../type/uploadInfoDataType";
+import useHover from "../../utils/hooks/useHover";
 
 interface PropsType {
   uploadData: UploadInfoDataType;
   setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
   setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
+  setUploadDataRef: React.Dispatch<React.SetStateAction<React.MutableRefObject<HTMLTextAreaElement | null> | null>>;
 }
 
 export default function TrackUpload(props: PropsType) {

--- a/src/@components/upload/trackUpload.tsx
+++ b/src/@components/upload/trackUpload.tsx
@@ -3,8 +3,6 @@ import styled, { css } from "styled-components";
 import UploadInfo from "../@common/uploadInfo";
 import TrackUploadDefaultImg from "../../assets/image/trackUploadDefaultImg.png";
 import { FileChangeIc } from "../../assets";
-import { uploadImage, setHover } from "../../utils/uploadPage/uploadImage";
-import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
 import { uploadImage } from "../../utils/uploadPage/uploadImage";
 import { UploadInfoDataType } from "../../type/uploadInfoDataType";
 import useHover from "../../utils/hooks/useHover";
@@ -12,7 +10,6 @@ import useHover from "../../utils/hooks/useHover";
 interface PropsType {
   uploadData: UploadInfoDataType;
   setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
-  setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
   setUploadDataRef: React.Dispatch<React.SetStateAction<React.MutableRefObject<HTMLTextAreaElement | null> | null>>;
 }
 
@@ -20,7 +17,7 @@ export default function TrackUpload(props: PropsType) {
   const { uploadData, setUploadData, setUploadDataRef } = props;
 
   const [trackUploadImg, setTrackUploadImg] = useState<string>(TrackUploadDefaultImg);
-  const [isHover, setIsHover] = useState<boolean>(false);
+  const { hoverState, changeHoverState } = useHover();
 
   return (
     <Container>
@@ -29,17 +26,17 @@ export default function TrackUpload(props: PropsType) {
           <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
             <TrackUploadImage
               src={trackUploadImg}
-              alt="썸네일이미지"
-              onMouseEnter={(e) => setHover(e, trackUploadImg, setIsHover)}
-              onMouseLeave={(e) => setHover(e, trackUploadImg, setIsHover)}
-              isHover={isHover}
+              alt="썸네일 이미지"
+              onMouseEnter={(e) => changeHoverState(e, trackUploadImg)}
+              onMouseLeave={(e) => changeHoverState(e, trackUploadImg)}
+              hoverState={hoverState}
             />
           </label>
           <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-            {isHover && (
+            {hoverState && (
               <FileChangeIcon
-                onMouseEnter={(e) => setHover(e, trackUploadImg, setIsHover)}
-                onMouseLeave={(e) => setHover(e, trackUploadImg, setIsHover)}
+                onMouseEnter={(e) => changeHoverState(e, trackUploadImg)}
+                onMouseLeave={(e) => changeHoverState(e, trackUploadImg)}
               />
             )}
           </label>
@@ -91,12 +88,13 @@ const TrackImageBox = styled.div`
   cursor: pointer;
 `;
 
-const TrackUploadImage = styled.img<{ isHover: boolean }>`
+const TrackUploadImage = styled.img<{ hoverState: boolean }>`
   width: 60.4rem;
   height: 60.4rem;
   object-fit: cover;
+  border-radius: 50%;
   ${(props) =>
-    props.isHover
+    props.hoverState
       ? css`
           background: rgba(30, 32, 37, 0.5);
           filter: blur(3rem);

--- a/src/@components/upload/vocalUpload.tsx
+++ b/src/@components/upload/vocalUpload.tsx
@@ -4,8 +4,6 @@ import UploadInfo from "../@common/uploadInfo";
 import VocalUploadDefaultImg from "../../assets/image/vocalUploadDefaultImg.png";
 import VocalUploadFrameIc from "../../assets/icon/vocalUploadFrameIc.svg";
 import { FileChangeIc } from "../../assets";
-import { uploadImage, setHover } from "../../utils/uploadPage/uploadImage";
-import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
 import { uploadImage } from "../../utils/uploadPage/uploadImage";
 import { UploadInfoDataType } from "../../type/uploadInfoDataType";
 import useHover from "../../utils/hooks/useHover";
@@ -13,7 +11,6 @@ import useHover from "../../utils/hooks/useHover";
 interface propsType {
   uploadData: UploadInfoDataType;
   setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
-  setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
   setUploadDataRef: React.Dispatch<React.SetStateAction<React.MutableRefObject<HTMLTextAreaElement | null> | null>>;
 }
 
@@ -21,23 +18,23 @@ export default function VocalUpload(props: propsType) {
   const { uploadData, setUploadData, setUploadDataRef } = props;
 
   const [vocalUploadImg, setVocalUploadImg] = useState<string>(VocalUploadDefaultImg);
-  const [isHover, setIsHover] = useState<boolean>(false);
+  const { hoverState, changeHoverState } = useHover();
 
   return (
     <Container>
       <SectionWrapper>
         <VocalImageBox>
           <VocalImageFrame
-            onMouseEnter={(e) => setHover(e, vocalUploadImg, setIsHover)}
-            onMouseLeave={(e) => setHover(e, vocalUploadImg, setIsHover)}>
+            onMouseEnter={(e) => changeHoverState(e, vocalUploadImg)}
+            onMouseLeave={(e) => changeHoverState(e, vocalUploadImg)}>
             <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-              <VocalUploadImage src={vocalUploadImg} alt="썸네일이미지" isHover={isHover} />
+              <VocalUploadImage src={vocalUploadImg} alt="썸네일이미지" hoverState={hoverState} />
             </label>
             <label htmlFor="imageFileUpload" style={{ cursor: "pointer" }}>
-              {isHover && (
+              {hoverState && (
                 <FileChangeIcon
-                  onMouseEnter={(e) => setHover(e, vocalUploadImg, setIsHover)}
-                  onMouseLeave={(e) => setHover(e, vocalUploadImg, setIsHover)}
+                  onMouseEnter={(e) => changeHoverState(e, vocalUploadImg)}
+                  onMouseLeave={(e) => changeHoverState(e, vocalUploadImg)}
                 />
               )}
             </label>
@@ -96,7 +93,7 @@ const VocalImageFrame = styled.div`
   object-fit: cover;
 `;
 
-const VocalUploadImage = styled.img<{ isHover: boolean }>`
+const VocalUploadImage = styled.img<{ hoverState: boolean }>`
   width: 59.8rem;
   height: 59.8rem;
   transform: rotate(-45deg);
@@ -104,7 +101,7 @@ const VocalUploadImage = styled.img<{ isHover: boolean }>`
   margin-top: -7.4rem;
   object-fit: cover;
   ${(props) =>
-    props.isHover
+    props.hoverState
       ? css`
           background: rgba(30, 32, 37, 0.5);
           filter: blur(3rem);

--- a/src/@components/upload/vocalUpload.tsx
+++ b/src/@components/upload/vocalUpload.tsx
@@ -6,11 +6,15 @@ import VocalUploadFrameIc from "../../assets/icon/vocalUploadFrameIc.svg";
 import { FileChangeIc } from "../../assets";
 import { uploadImage, setHover } from "../../utils/uploadPage/uploadImage";
 import { UploadInfoDataType, UploadInfoRefType } from "../../type/uploadInfoDataType";
+import { uploadImage } from "../../utils/uploadPage/uploadImage";
+import { UploadInfoDataType } from "../../type/uploadInfoDataType";
+import useHover from "../../utils/hooks/useHover";
 
 interface propsType {
   uploadData: UploadInfoDataType;
   setUploadData: React.Dispatch<React.SetStateAction<UploadInfoDataType>>;
   setUploadDataRef: React.Dispatch<React.SetStateAction<UploadInfoRefType>>;
+  setUploadDataRef: React.Dispatch<React.SetStateAction<React.MutableRefObject<HTMLTextAreaElement | null> | null>>;
 }
 
 export default function VocalUpload(props: propsType) {

--- a/src/@pages/uploadPage.tsx
+++ b/src/@pages/uploadPage.tsx
@@ -3,7 +3,7 @@ import VocalUpload from "../@components/upload/vocalUpload";
 import { useRecoilValue } from "recoil";
 import { UserType } from "../recoil/main";
 import { useParams } from "react-router-dom";
-import { UploadInfoDataType, UploadInfoRefType } from "../type/uploadInfoDataType";
+import { UploadInfoDataType } from "../type/uploadInfoDataType";
 import { useState } from "react";
 import TrackUploadDefaultImg from "../assets/image/trackUploadDefaultImg.png";
 import VocalUploadDefaultImg from "../assets/image/vocalUploadDefaultImg.png";
@@ -23,9 +23,7 @@ export default function UploadPage() {
     jacketImage: getDefaultImage(),
   });
 
-  const [uploadDataRef, setUploadDataRef] = useState<UploadInfoRefType>({
-    introduceRef: null,
-  });
+  const [uploadDataRef, setUploadDataRef] = useState<React.MutableRefObject<HTMLTextAreaElement | null> | null> (null);
 
   function getDefaultImage(): FormData {
     let defaultImage = new FormData();

--- a/src/@pages/uploadPage.tsx
+++ b/src/@pages/uploadPage.tsx
@@ -7,7 +7,7 @@ import { UploadInfoDataType, UploadInfoRefType } from "../type/uploadInfoDataTyp
 import { useState } from "react";
 import TrackUploadDefaultImg from "../assets/image/trackUploadDefaultImg.png";
 import VocalUploadDefaultImg from "../assets/image/vocalUploadDefaultImg.png";
-import { isMaker } from "../utils/common/userType";
+import { checkUserType } from "../utils/common/userType";
 import UploadHeader from "../@components/@common/uploadHeader";
 
 export default function UploadPage() {
@@ -29,7 +29,7 @@ export default function UploadPage() {
 
   function getDefaultImage(): FormData {
     let defaultImage = new FormData();
-    isMaker(userType)
+    checkUserType(userType)
       ? defaultImage.append("defaultImage", TrackUploadDefaultImg)
       : defaultImage.append("defaultImage", VocalUploadDefaultImg);
 
@@ -45,7 +45,7 @@ export default function UploadPage() {
         setUploadData={setUploadData}
         uploadDataRef={uploadDataRef}
       />
-      {isMaker(userType) ? (
+      {checkUserType(userType) ? (
         <TrackUpload uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />
       ) : (
         <VocalUpload uploadData={uploadData} setUploadData={setUploadData} setUploadDataRef={setUploadDataRef} />

--- a/src/type/uploadInfoDataType.ts
+++ b/src/type/uploadInfoDataType.ts
@@ -6,7 +6,3 @@ export interface UploadInfoDataType {
   keyword: Array<string>;
   jacketImage: File | Blob | FormData;
 }
-
-export interface UploadInfoRefType {
-  introduceRef: React.MutableRefObject<HTMLTextAreaElement | null> | null;
-}

--- a/src/utils/common/userType.ts
+++ b/src/utils/common/userType.ts
@@ -1,5 +1,5 @@
 import { currentUser } from "../../core/constants/userType";
 
-export function isMaker(userType: string): boolean {
+export function checkUserType(userType: string): boolean {
   return userType === currentUser.PRODUCER;
 }

--- a/src/utils/hooks/useHover.ts
+++ b/src/utils/hooks/useHover.ts
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import { isDefaultImage } from "../uploadPage/uploadImage";
+
+export default function useHover() {
+  const [hoverState, setHoverState] = useState<boolean>(false);
+
+  function changeHoverState(argument1: React.MouseEvent, argument2?: string) {
+    if (argument2 !== undefined) {
+      !isDefaultImage(argument2) && argument1.type === "mouseenter" ? setHoverState(true) : setHoverState(false);
+      return { hoverState, changeHoverState };
+    } else {
+      argument1.type === "mouseenter" ? setHoverState(true) : setHoverState(false);
+      return { hoverState, changeHoverState };
+    }
+  }
+
+  return { hoverState, changeHoverState };
+}

--- a/src/utils/uploadPage/uploadImage.ts
+++ b/src/utils/uploadPage/uploadImage.ts
@@ -2,7 +2,6 @@ import { fileSize } from "../../core/constants/fileSize";
 import TrackUploadDefaultImg from "../../assets/image/trackUploadDefaultImg.png";
 import VocalUploadDefaultImg from "../../assets/image/vocalUploadDefaultImg.png";
 import { UploadInfoDataType } from "../../type/uploadInfoDataType";
-import { isMouseEnter } from "../../utils/common/eventType";
 
 export function uploadImage(
   e: React.ChangeEvent<HTMLInputElement>,
@@ -20,16 +19,6 @@ export function uploadImage(
         return { ...prevState, jacketImage: file };
       });
     }
-  }
-}
-
-export function setHover(
-  e: React.MouseEvent<HTMLDivElement | SVGSVGElement>,
-  defaultImage: string,
-  setIsHover: React.Dispatch<React.SetStateAction<boolean>>,
-) {
-  if (!isDefaultImage(defaultImage)) {
-    isMouseEnter(e) ? setIsHover(true) : setIsHover(false);
   }
 }
 


### PR DESCRIPTION
### ✅ 구현기능 명세
- [x] Category상수로 빼서 구현
- [x] Array 컨벤션 맞춰서 구현
- [ ] setState 함수로 감싸줘서 props 전달하기
- [x] 기존 네이밍 컨벤션에 맞춰서 함수명 변경
- [x] hover -> useHover 커스텀훅 빼기
- [x] uploadDataRef : key&value 형태에서 단일 state로 변경
### 📝 이렇게 구현해봤어요
1. CATEGORY 상수로 분리
- 기존 해당페이지 컴포넌트에서 사용하는 상수를 전역 상수폴더에 설정해서 객체를 순회하는 방식으로 변경했어요. 

2. Array 컨벤션 지키기
- 리티럴 배열로 선언해주고 useEffect로 처음 렌더링 될 때 카테고리 길이만큼 false값이 들어간 초기배열을 getInitFalseArray를 통해 받아와서 할당해주었어요.

3. useHover 커스텀훅
- 단순하게 mouseEnter만 되었을 때 값이 변경되어야 할때랑 조건에 따라서 호버되는 상태가 바뀌어야 하는게 달라서, 코드의 재사용성(?)을 높이려고  드디어 전공수업때 배웠던 함수 오버로딩을 사용해봤어요. 
단순하게  mouseEnter가 되면 변수가 바뀌는 부분은 인자를 event 하나만 받아서 type에 따라 값들을 변경해줬고, 
이미지가 존재할 때의 조건을 봐야하는 부분은 인자를 두개를 넘겨주어서 조건에 따른 값들을 변경해줄 수 있도록 구현했어요!

### 🙌🏻 같이 고민했으면 하는 부분
1. Anti pattern
- 안티패턴을 알아보면서 저희 공통적으로 사용하고 있는 안티패턴이 있더라구요!!(공통적이 아니라면 저 혼자...ㅠㅠ)
map을 이용해서 key값에 index를 주는게 좋지 않다고 하네요!! 나중에 리팩토링할때 변경해봐야겠어요!

2. useHover
-사실 커스텀 훅을 빼면서도 hover되는 조건이 mouseEnter 뿐아니라 focus도 hover를 줘야하는데 처리하는데 시간이 오래걸릴거 같아서 하지 못했는데 이부분까지도 같이 처리를 해야할지 고민돼요!
focus하는 조건도 굉장히 다양할텐데 이걸 커스텀훅 처리를 해야할지........고민됩니다!!!