### PR TITLE
QA#330 trackSearch/infinite

### DIFF
--- a/src/@pages/trackSearchPage.tsx
+++ b/src/@pages/trackSearchPage.tsx
@@ -51,6 +51,7 @@ export default function TrackSearchPage() {
       getNextPageParam: (lastPage, allPages) => {
         return lastPage?.response.length !== 0 ? lastPage?.nextPage : undefined;
       },
+      refetchOnWindowFocus: false,
     },
   );
 


### PR DESCRIPTION
### ✅ 구현기능 명세

track-search 무한스크롤에서 타 페이지 이동 후 재방문 시 함수 실행 현상 막기
(타 무한스크롤에서도 같은 문제이고 같은 해결방법임)

### 📝 이렇게 구현해봣어요

    
  `refetchOnWindowFocus: false`


### 🙌🏻 같이 고민했으면 하는 부분
