### PR TITLE
Qa#332 track search/get data

### DIFF
--- a/src/@components/@common/categoryHeader.tsx
+++ b/src/@components/@common/categoryHeader.tsx
@@ -18,24 +18,26 @@ import { LoginUserId, LoginUserImg, LoginUserType } from "../../recoil/loginUser
 import { isProducer } from "../../utils/common/userType";
 import { categorySelect, clickCategoryHeader } from "../../recoil/categorySelect";
 
-export default function CategoryHeader() {
+export default function CategoryHeader(props: any) {
+  const { excuteGetData } = props;
+
   const navigate = useNavigate();
   const [tracksOrVocals, setTracksOrVocals] = useRecoilState<any>(tracksOrVocalsCheck);
   const loginUserType = useRecoilValue(LoginUserType);
   const loginUserId = useRecoilValue(LoginUserId);
-  const loginUserImg=useRecoilValue(LoginUserImg);
+  const loginUserImg = useRecoilValue(LoginUserImg);
   const [isClickedCategory, setIsClickedCategory] = useRecoilState(clickCategoryHeader);
 
   function moveTrackSearchPage() {
     setTracksOrVocals(Category.TRACKS);
     navigate("/track-search");
-    setIsClickedCategory(!isClickedCategory)
+    setIsClickedCategory(!isClickedCategory);
   }
 
   function moveVocalSearchPage() {
     setTracksOrVocals(Category.VOCALS);
     navigate("/vocal-search");
-    setIsClickedCategory(!isClickedCategory)
+    setIsClickedCategory(!isClickedCategory);
   }
 
   function moveMainPage() {
@@ -54,14 +56,32 @@ export default function CategoryHeader() {
         <CategoryWrapper>
           {tracksOrVocals === Category.TRACKS && (
             <>
-              <TracksSelectTextIcon onClick={moveTrackSearchPage} />
-              <VocalsHeaderTextIcon onClick={moveVocalSearchPage} />
+              <TracksSelectTextIcon
+                onClick={() => {
+                  moveTrackSearchPage();
+                  excuteGetData();
+                }}
+              />
+              <VocalsHeaderTextIcon
+                onClick={() => {
+                  moveVocalSearchPage();
+                }}
+              />
             </>
           )}
           {tracksOrVocals === Category.VOCALS && (
             <>
-              <TracksHeaderTextIcon onClick={moveTrackSearchPage} />
-              <VocalsSelectTextIcon onClick={moveVocalSearchPage} />
+              <TracksHeaderTextIcon
+                onClick={() => {
+                  moveTrackSearchPage();
+                  excuteGetData();
+                }}
+              />
+              <VocalsSelectTextIcon
+                onClick={() => {
+                  moveVocalSearchPage();
+                }}
+              />
             </>
           )}
         </CategoryWrapper>
@@ -75,17 +95,11 @@ export default function CategoryHeader() {
               src={"https://track1-default.s3.ap-northeast-2.amazonaws.com/default_user2.png"}
               alt="프로필이미지"
             /> */}
-             {
-              isProducer(loginUserType)?(
-              <ProducerProfileImg
-                src={loginUserImg}
-                alt="프로필이미지"
-              />):(
+            {isProducer(loginUserType) ? (
+              <ProducerProfileImg src={loginUserImg} alt="프로필이미지" />
+            ) : (
               <VocalProfileImageWrapper>
-              <VocalProfileImage
-                src={loginUserImg}
-                alt="프로필이미지"
-              />
+                <VocalProfileImage src={loginUserImg} alt="프로필이미지" />
               </VocalProfileImageWrapper>
             )}
             <ToggleIc />

--- a/src/@components/@common/categoryHeader.tsx
+++ b/src/@components/@common/categoryHeader.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { useRef } from "react";
 import styled from "styled-components";
 import { Category } from "../../core/constants/categoryHeader";
 
@@ -20,6 +21,7 @@ import { categorySelect, clickCategoryHeader } from "../../recoil/categorySelect
 
 export default function CategoryHeader(props: any) {
   const { excuteGetData } = props;
+  const isSameClicked = useRef(false);
 
   const navigate = useNavigate();
   const [tracksOrVocals, setTracksOrVocals] = useRecoilState<any>(tracksOrVocalsCheck);
@@ -28,10 +30,26 @@ export default function CategoryHeader(props: any) {
   const loginUserImg = useRecoilValue(LoginUserImg);
   const [isClickedCategory, setIsClickedCategory] = useRecoilState(clickCategoryHeader);
 
+  const isSameCategoryCliked = () => {
+    if (!isSameClicked.current) {
+      isSameClicked.current = true;
+    }
+  };
+
+  function clickSameCategory() {
+    isSameCategoryCliked();
+    if (isSameClicked.current === false) {
+      excuteGetData();
+    } else {
+      window.scrollTo(0, 0);
+    }
+  }
+
   function moveTrackSearchPage() {
     setTracksOrVocals(Category.TRACKS);
     navigate("/track-search");
     setIsClickedCategory(!isClickedCategory);
+    clickSameCategory();
   }
 
   function moveVocalSearchPage() {
@@ -56,32 +74,14 @@ export default function CategoryHeader(props: any) {
         <CategoryWrapper>
           {tracksOrVocals === Category.TRACKS && (
             <>
-              <TracksSelectTextIcon
-                onClick={() => {
-                  moveTrackSearchPage();
-                  excuteGetData();
-                }}
-              />
-              <VocalsHeaderTextIcon
-                onClick={() => {
-                  moveVocalSearchPage();
-                }}
-              />
+              <TracksSelectTextIcon onClick={moveTrackSearchPage} />
+              <VocalsHeaderTextIcon onClick={moveVocalSearchPage} />
             </>
           )}
           {tracksOrVocals === Category.VOCALS && (
             <>
-              <TracksHeaderTextIcon
-                onClick={() => {
-                  moveTrackSearchPage();
-                  excuteGetData();
-                }}
-              />
-              <VocalsSelectTextIcon
-                onClick={() => {
-                  moveVocalSearchPage();
-                }}
-              />
+              <TracksHeaderTextIcon onClick={moveTrackSearchPage} />
+              <VocalsSelectTextIcon onClick={moveVocalSearchPage} />
             </>
           )}
         </CategoryWrapper>

--- a/src/@components/@common/categoryHeader.tsx
+++ b/src/@components/@common/categoryHeader.tsx
@@ -56,6 +56,7 @@ export default function CategoryHeader(props: any) {
     setTracksOrVocals(Category.VOCALS);
     navigate("/vocal-search");
     setIsClickedCategory(!isClickedCategory);
+    clickSameCategory();
   }
 
   function moveMainPage() {

--- a/src/@pages/trackSearchPage.tsx
+++ b/src/@pages/trackSearchPage.tsx
@@ -21,9 +21,12 @@ import { categorySelect } from "../recoil/categorySelect";
 import usePlayer from "../utils/hooks/usePlayer";
 import { AudioInfosType } from "../type/audioTypes";
 import useInfiniteScroll from "../utils/hooks/useInfiniteScroll";
+import useInfiniteKey from "../utils/hooks/useInfiniteKey";
 
 export default function TrackSearchPage() {
   const [tracksData, setTracksData] = useState<TracksDataType[]>([]);
+  const { key, excuteGetData } = useInfiniteKey();
+
   const [audioInfos, setAudioInfos] = useState({});
 
   const [play, setPlay] = useRecoilState<boolean>(playMusic);
@@ -45,10 +48,11 @@ export default function TrackSearchPage() {
   }
 
   const { data, isSuccess, hasNextPage, fetchNextPage, isFetchingNextPage } = useInfiniteQuery(
-    "trackSearch",
+    key,
     ({ pageParam = 1 }) => getData(pageParam),
     {
       getNextPageParam: (lastPage, allPages) => {
+        //console.log(key);
         return lastPage?.response.length !== 0 ? lastPage?.nextPage : undefined;
       },
       refetchOnWindowFocus: false,
@@ -68,7 +72,7 @@ export default function TrackSearchPage() {
 
   return (
     <>
-      <CategoryHeader />
+      <CategoryHeader excuteGetData={excuteGetData} />
       <TrackSearchPageWrapper>
         <CategoryListWrapper>
           <CategoryList />

--- a/src/@pages/vocalsPage.tsx
+++ b/src/@pages/vocalsPage.tsx
@@ -19,6 +19,8 @@ import { useInfiniteQuery } from "react-query";
 import { VocalsDataType } from "../type/vocalsDataType";
 import usePlayer from "../utils/hooks/usePlayer";
 import useInfiniteScroll from "../utils/hooks/useInfiniteScroll";
+import useInfiniteKey from "../utils/hooks/useInfiniteKey";
+
 
 export default function VocalsPage() {
   const [vocalsData, setVocalsData] = useState<VocalsDataType[]>([]);
@@ -37,13 +39,15 @@ export default function VocalsPage() {
   const filteredUrlApi = useRecoilValue(categorySelect);
 
   const { progress, audio } = usePlayer();
+  const { key, excuteGetData } = useInfiniteKey();
+
 
   useEffect(() => {
     setWhom(Category.VOCALS); // 나중에 헤더에서 클릭했을 때도 변경되도록 구현해야겠어요
   }, []);
 
   const { data, isSuccess, hasNextPage, fetchNextPage, isFetchingNextPage } = useInfiniteQuery(
-    "vocalSearch",
+    key,
     ({ pageParam = 1 }) => getData(pageParam),
     {
       getNextPageParam: (lastPage, allPages) => {

--- a/src/utils/hooks/useInfiniteKey.ts
+++ b/src/utils/hooks/useInfiniteKey.ts
@@ -1,13 +1,11 @@
 import { useState } from "react";
 
 export default function useInfiniteKey() {
-  const [key, setKey] = useState("");
-  //const excuteGetData = () => setKey(Math.random().toString(36));
+  const [key, setKey] = useState(Math.random().toString(36));
 
   function excuteGetData() {
     setKey(Math.random().toString(36));
   }
 
-  console.log(key);
   return { key, excuteGetData };
 }

--- a/src/utils/hooks/useInfiniteKey.ts
+++ b/src/utils/hooks/useInfiniteKey.ts
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+export default function useInfiniteKey() {
+  const [key, setKey] = useState("");
+  //const excuteGetData = () => setKey(Math.random().toString(36));
+
+  function excuteGetData() {
+    setKey(Math.random().toString(36));
+  }
+
+  console.log(key);
+  return { key, excuteGetData };
+}


### PR DESCRIPTION
### ✅ 구현기능 명세
track search와 vocals 페이지에서 데이터들을 불러올 때 발생하는 getData() + 무한스크롤 오류 해결


### 📝 이렇게 구현해봣어요

1. key 값을 변경시키는 hook 파일 작성

*  key값을 왜 random으로 변경시키나요? => 무한스크롤 함수에서 getData를 통해 관련 데이터들을 불러오고 있는데, 이 함수가 하나의 이름을 가지면 함수가 실행될 때마다 초기화되지 않고 축적됩니다. 그래서 데이터가 제대로 안불러와진다던가, 데이터가 중복으로 불러와지는 등의 오류가 발생합니다. 따라서 key값을 계속해서 바꿔주면서 초기화된 함수를 불러와줘야합니다.

2. track search와 vocals 페이지는 trackSearchPage.tsx와 vocalsPage.tsx로 나누어져있으며, 내부에 카테고리 해더 컴포넌트를 이용하여 두 페이지를 경로 설정 및 띄워주게 됩니다. 그래서 click이벤트와 무한스크롤(getData실행함수) 함수의 위치가 달리 있어서 props를 이용해서 hook의 return 값을 받아오게 만들었습니다.

3. categoryHeader.tsx에서 만약 같은 탭메뉴를 클릭했을 때에는 그냥 scroll만 상단으로 올려주고 다른 탭메뉴에서 돌아올 때에야 비로소 key값을 변경시켜 초기화된 무한스크롤함수를 재실행해주게 했습니다. (여기에서 탭메뉴 변경 사항을 useRef를 이용했는데, state를 사용하면 컴포넌트 랜더링때마다 초기화되면 낭비가 발생해서 그랬습니다. ) 
```
  function clickSameCategory() {
    isSameCategoryCliked();
    if (isSameClicked.current === false) {
      excuteGetData();
    } else {
      window.scrollTo(0, 0);
    }
  }
```

### 🙌🏻 같이 고민했으면 하는 부분

* 함수.. 컨벤션 안지켜서 리팩토링 하거나 야금야금 수정 봐야겠습니다..
* 상당수의 컴포넌트에서 click시 새로 초기화된 무한스크롤 함수를 이용해 getData()를 불러와야하는데 그럼 중복되는 코드가 너무 많을거같아서 이걸 또 어떻게 리팩토링하는게 좋을지 궁금합니다!