### PR TITLE
Qa#441 track search/category

### DIFF
--- a/src/@components/@common/categoryList.tsx
+++ b/src/@components/@common/categoryList.tsx
@@ -68,6 +68,9 @@ export default function CategoryList(props: any) {
       : (tempSelectedCategors[id].selected = true);
     setSelectedCategorys([...tempSelectedCategors]);
     setIsCategorySelected(true);
+
+    pausesPlayerAudio();
+    setShowPlayer(false);
   }
 
   function moveUploadPage() {

--- a/src/@components/trackSearch/trackList.tsx
+++ b/src/@components/trackSearch/trackList.tsx
@@ -21,10 +21,11 @@ interface PropsType {
   tracksData: TracksDataType[];
   getInfos: any;
   excuteGetData: any;
+  key: string;
 }
 
 export default function TrackList(props: PropsType) {
-  const { audio, pauseAudio, tracksData, getInfos, excuteGetData } = props;
+  const { audio, pauseAudio, tracksData, getInfos, excuteGetData, key } = props;
 
   const navigate = useNavigate();
 
@@ -92,7 +93,7 @@ export default function TrackList(props: PropsType) {
         <HashtagTextIcon />
       </CategoryWrapper>
 
-      <TracksWrapper>
+      <TracksWrapper key={key}>
         {tracksData.map((track, index) => (
           <Tracks
             key={track.beatId}

--- a/src/@pages/trackSearchPage.tsx
+++ b/src/@pages/trackSearchPage.tsx
@@ -100,6 +100,7 @@ export default function TrackSearchPage() {
               tracksData={tracksData}
               getInfos={getInfos}
               excuteGetData={excuteGetData}
+              key={key}
             />
           )}
         </TrackListWrapper>


### PR DESCRIPTION
### ✅ 구현기능 명세
![image](https://user-images.githubusercontent.com/88815795/230726941-b65eee4d-6a3a-4ccc-b20a-f3f31328ee51.png)

### 📝 이렇게 구현해봣어요

div 에 key 이 변경되면 div 내부의 것들이 재 랜더링 됩니다.

그래서 무한스크롤 때문에 카테고리 클릭할 때마다 바꿔줬던 key값을 props로 넘겨줘서
div 태그에 key값으로 넣어줬어요~!

추가로 카테고리 바뀔때마다 노래와 플레이바는 제거되도록 설정해주면 끝!


### 🙌🏻 같이 고민했으면 하는 부분
