### PR TITLE
[ fix ] 모든 리코일 삭제되는 문제 해결

### DIFF
--- a/src/@components/@common/categoryList.tsx
+++ b/src/@components/@common/categoryList.tsx
@@ -93,6 +93,8 @@ export default function CategoryList(props: any) {
       : alert("Please use this function after producer logging in.\n해당 기능은 프로듀서로 로그인 후 이용해주세요.");
   }
 
+  // console.log(userType);
+
   function changeCategoryColor(id: number) {
     if (selectedCategorys[id]?.selected) {
       switch (tracksOrVocals) {

--- a/src/@components/login/loginInput.tsx
+++ b/src/@components/login/loginInput.tsx
@@ -1,29 +1,29 @@
+import { useEffect, useState } from "react";
+import { useMutation } from "react-query";
+import { Link, useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
 import styled, { css } from "styled-components";
 import {
-  ProducerDefaultModeToggleIc,
-  ProducerModeToggleIc,
-  ProducerLoginBtnIc,
-  VocalLoginBtnIc,
   DefaultLoginBtnIc,
-  LoginTitleIc,
   IfyourareanewuserIc,
-  SignuphereIc,
-  LoginforgotpasswordIc,
   LoginEmailIc,
   LoginPasswordIc,
+  LoginTitleIc,
+  LoginforgotpasswordIc,
+  ProducerDefaultModeToggleIc,
+  ProducerLoginBtnIc,
+  ProducerModeToggleIc,
+  SignUpErrorIc,
   SignUpEyeIc,
   SignUpEyeXIc,
-  SignUpErrorIc,
+  SignuphereIc,
+  VocalLoginBtnIc,
 } from "../../assets";
-import { useEffect, useState } from "react";
 import { onLogin } from "../../core/api/login";
-import { Link, useNavigate } from "react-router-dom";
-import { useMutation } from "react-query";
-import { setCookie } from "../../utils/cookie";
 import { LoginUserId, LoginUserType } from "../../recoil/loginUserData";
-import { useSetRecoilState } from "recoil";
-import { checkPasswordForm } from "../../utils/errorMessage/checkPasswordForm";
+import { setCookie } from "../../utils/cookie";
 import { checkEmailForm } from "../../utils/errorMessage/checkEmailForm";
+import { checkPasswordForm } from "../../utils/errorMessage/checkPasswordForm";
 import Loading from "../@common/loading";
 
 export default function LoginInput() {
@@ -54,6 +54,7 @@ export default function LoginInput() {
   const { mutate, isLoading } = useMutation(() => onLogin(email, password, loginType), {
     onSuccess: (data) => {
       if (data?.data.status === 200) {
+        console.log(data);
         const accessToken = data.data.data.accessToken;
         setLoginUserType(data.data.data.tableName);
         setLoginUserId(data.data.data.id);

--- a/src/@pages/mainPage.tsx
+++ b/src/@pages/mainPage.tsx
@@ -14,10 +14,11 @@ import hoverVocalsImg from "../assets/image/hoverVocalsImg.png";
 import mainBackgroundImg from "../assets/image/mainBackgroundImg.png";
 import mainSloganImg from "../assets/image/mainSloganImg.png";
 import { Category } from "../core/constants/categoryHeader";
-import { clickCategoryHeader } from "../recoil/categorySelect";
+import { categoryFinalSelectedCheck, clickCategoryHeader } from "../recoil/categorySelect";
 import { openConventionModal } from "../recoil/conventionModal";
 import { reload } from "../recoil/main";
 import { tracksOrVocalsCheck } from "../recoil/tracksOrVocalsCheck";
+import { CategoryChecksType } from "../type/CategoryChecksType";
 
 export default function MainPage() {
   const navigate = useNavigate();
@@ -30,9 +31,22 @@ export default function MainPage() {
 
   const [tracksOrVocals, setTracksOrVocals] = useRecoilState(tracksOrVocalsCheck);
   const [isClickedCategory, setIsClickedCategory] = useRecoilState(clickCategoryHeader);
+  const [selectedCategorys, setSelectedCategorys] = useRecoilState<CategoryChecksType[]>(categoryFinalSelectedCheck);
 
   useEffect(() => {
-    localStorage.removeItem("recoil-persist");
+    // localStorage.removeItem("recoil-persist");
+    setSelectedCategorys([
+      { categId: 0, selected: false },
+      { categId: 1, selected: false },
+      { categId: 2, selected: false },
+      { categId: 3, selected: false },
+      { categId: 4, selected: false },
+      { categId: 5, selected: false },
+      { categId: 6, selected: false },
+      { categId: 7, selected: false },
+      { categId: 8, selected: false },
+      { categId: 9, selected: false },
+    ]);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
### ✅ 구현기능 명세
메인페이지 접속 시 모든 리코일 삭제해버려서 생기는 오류 해결

### 📝 이렇게 구현해봣어요
`localStorage.removeItem("recoil-persist"); `이렇게 하니까 모든 리코일이 리셋되어서, 

 ```
   setSelectedCategorys([
      { categId: 0, selected: false },
      { categId: 1, selected: false },
      { categId: 2, selected: false },
      { categId: 3, selected: false },
      { categId: 4, selected: false },
      { categId: 5, selected: false },
      { categId: 6, selected: false },
      { categId: 7, selected: false },
      { categId: 8, selected: false },
      { categId: 9, selected: false },
    ]);

```
이렇게 바뀐 내용만 변경되도록 변경해주었습니다.

### 🙌🏻 같이 고민했으면 하는 부분
