### PR TITLE
[ fix ] useAudioFIle 커스텀훅 반환 변수 변경으로 인한 에러 해결

### DIFF
--- a/src/@components/trackPost/commentFileInput.tsx
+++ b/src/@components/trackPost/commentFileInput.tsx
@@ -9,19 +9,19 @@ import { CommentIsUpdateProp } from "../../type/trackPost/commentIsUpdateProp";
 export default function CommentFileInput(props: CommentIsUpdateProp) {
   const { isUpdate } = props;
   const [comment, setComment] = useRecoilState(isUpdate ? commentUpdateData : commentWriteData);
-  const { audioInit, uploadAudiofile } = useUploadAudioFile();
+  const { audioFile, audioFileName, handleUploadAudioFile } = useUploadAudioFile();
 
   useEffect(() => {
-    if (!audioInit?.audioFile || audioInit?.fileName === "") return;
-    setComment({ ...comment, commentAudioFileName: audioInit?.fileName, commentAudioFile: audioInit?.audioFile });
-  }, [audioInit]);
+    if (!audioFile || audioFileName === "") return;
+    setComment({ ...comment, commentAudioFileName: audioFileName, commentAudioFile: audioFile });
+  }, [audioFile, audioFileName]);
 
   return (
     <CommentFileInputWrapper>
       <InputTitle>{comment?.commentAudioFileName}</InputTitle>
       <label>
         <FileUploadButtonIcon />
-        <FileInput type="file" accept=".mp3, .wav" onChange={uploadAudiofile} />
+        <FileInput type="file" accept=".mp3, .wav" onChange={handleUploadAudioFile} />
       </label>
     </CommentFileInputWrapper>
   );

--- a/src/hooks/common/useUploadAudioFile.ts
+++ b/src/hooks/common/useUploadAudioFile.ts
@@ -1,10 +1,8 @@
 import { useState } from "react";
 import { TEXT_LIMIT } from "../../core/common/textLimit";
-import { AudioElement } from "../../type/upload/uploadinitType";
-import { checkAudioFileType } from "../../utils/common/checkAudioFileType";
 import { checkMaxInputLength } from "../../utils/common/checkMaxInputLength";
-import useUploadInitValue from "../upload/useUploadInitValue";
 import { uploadAudioTypeWarningMessage } from "../../core/common/warningMessage";
+import { checkAudioFileType } from "../../utils/common/checkFileType";
 
 export default function useUploadAudioFile() {
   const [audioFile, setAudioFile] = useState<File | null>(null);


### PR DESCRIPTION
### ✅ 구현기능 명세
- 에러수정
### 📝 이렇게 구현해봣어요
- useAudioFile 커스텀훅 반환변수를 기존에 객체로 반환했는데 변수별로 각자 내보내기했어요!
### 🙌🏻 같이 고민했으면 하는 부분
