### PR TITLE
Feat#812 portfolio/contact

### DIFF
--- a/src/@components/profile/index.tsx
+++ b/src/@components/profile/index.tsx
@@ -67,7 +67,7 @@ const Contact = styled.h2`
   ${({ theme }) => theme.fonts.hashtag}
 
   color: ${({ theme }) => theme.colors.gray1};
-
+  user-select: text;
   margin-top: 1.2rem;
   height: 1.2rem;
 `;

--- a/src/@components/upload/descriptionInput.tsx
+++ b/src/@components/upload/descriptionInput.tsx
@@ -1,5 +1,5 @@
-import styled from "styled-components";
 import TextareaAutosize from "react-textarea-autosize";
+import styled from "styled-components";
 import { TEXT_LIMIT } from "../../core/common/textLimit";
 import { theme } from "../../style/theme";
 import { checkEnterCount } from "../../utils/common/checkEnterCount";
@@ -54,8 +54,13 @@ const DescriptionText = styled(TextareaAutosize)`
   padding-bottom: 1rem;
 
   white-space: pre-wrap;
+  outline: none;
   word-wrap: break-word;
   word-break: break-word;
+  background: transparent;
+  border-top: transparent;
+  border-left: transparent;
+  border-right: transparent;
 
   ::placeholder {
     color: ${({ theme }) => theme.colors.gray3};


### PR DESCRIPTION
### ✅ 구현 명세
- 포트폴리오 수정 디스크립션 디폴트 스타일 제거
- 포트폴리오 contact 선택해서 복사가능하도록 스타일 추가

### 📝 이렇게 구현해봣어요
`user-select : text` css 속성을 추가하면 텍스트를 선택해서 복사 가능하더라고요!

### 🙌🏻 같이 고민했으면 하는 부분
