### PR TITLE
Fix#834 track post/animation

### DIFF
--- a/src/@components/@common/player.tsx
+++ b/src/@components/@common/player.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import styled from "styled-components";
 import { PlayerPlayIc, PlayerQuitIc, PlayerStopIc } from "../../assets";
 import { PlayerContext } from "../../context/playerContext";
@@ -192,6 +192,12 @@ export default function Player({ comment }: PlayerProps) {
     quitAudio();
     closeAudioPlayer();
   }
+
+  useEffect(() => {
+    if (currentTimeText === totalTimetext) {
+      stopContextState();
+    }
+  }, [currentTimeText]);
 
   return showPlayer ? (
     <PlayerContainer>

--- a/src/@components/trackPost/audioJacketImage.tsx
+++ b/src/@components/trackPost/audioJacketImage.tsx
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 import { useParams } from "react-router-dom";
 import styled, { css, keyframes } from "styled-components";
+import { CommentsPlayerContext } from ".";
 import { PlayerContext } from "../../context/playerContext";
 import { useTrackDetail } from "../../hooks/queries/tracks";
 
@@ -8,9 +9,10 @@ export default function AudioJacketImage() {
   const { id } = useParams();
   const { trackDetail } = useTrackDetail(Number(id));
   const { contextPlaying } = useContext(PlayerContext);
+  const { contextPlaying: commentContextPlaying } = useContext(CommentsPlayerContext);
 
   return (
-    <PlayImageWrapper isPlay={contextPlaying}>
+    <PlayImageWrapper isPlay={!commentContextPlaying && contextPlaying}>
       <PlayerImage src={trackDetail?.trackImageFile} alt="재생 이미지" />
     </PlayImageWrapper>
   );

--- a/src/@components/trackPost/audioJacketImage.tsx
+++ b/src/@components/trackPost/audioJacketImage.tsx
@@ -3,16 +3,18 @@ import { useParams } from "react-router-dom";
 import styled, { css, keyframes } from "styled-components";
 import { CommentsPlayerContext } from ".";
 import { PlayerContext } from "../../context/playerContext";
+import useControlPlayer from "../../hooks/common/useControlPlayer";
 import { useTrackDetail } from "../../hooks/queries/tracks";
 
 export default function AudioJacketImage() {
   const { id } = useParams();
   const { trackDetail } = useTrackDetail(Number(id));
-  const { contextPlaying } = useContext(PlayerContext);
+  const { contextPlaying, audio } = useContext(PlayerContext);
   const { contextPlaying: commentContextPlaying } = useContext(CommentsPlayerContext);
+  const { currentTimeText, totalTimetext } = useControlPlayer(audio, contextPlaying);
 
   return (
-    <PlayImageWrapper isPlay={!commentContextPlaying && contextPlaying}>
+    <PlayImageWrapper isPlay={!commentContextPlaying && contextPlaying} isMusicEnd={currentTimeText === totalTimetext}>
       <PlayerImage src={trackDetail?.trackImageFile} alt="재생 이미지" />
     </PlayImageWrapper>
   );
@@ -22,7 +24,7 @@ const RotateImage = keyframes`
     100% {transform: rotate(360deg)};
     `;
 
-const PlayImageWrapper = styled.div<{ isPlay: boolean }>`
+const PlayImageWrapper = styled.div<{ isPlay: boolean; isMusicEnd: boolean }>`
   height: 60.4rem;
   width: 60.4rem;
 
@@ -36,10 +38,14 @@ const PlayImageWrapper = styled.div<{ isPlay: boolean }>`
 
   overflow: hidden;
 
-  ${({ isPlay }) =>
+  ${({ isPlay, isMusicEnd }) =>
     isPlay
       ? css`
           -webkit-animation: ${RotateImage} 15s infinite linear;
+        `
+      : isMusicEnd
+      ? css`
+          transform: rotate(0deg);
         `
       : css`
           -webkit-animation: ${RotateImage} 15s infinite linear paused;

--- a/src/@components/trackPost/commentLayout.tsx
+++ b/src/@components/trackPost/commentLayout.tsx
@@ -3,10 +3,18 @@ import styled from "styled-components";
 
 export default function CommentLayout(props: PropsWithChildren) {
   const { children } = props;
-  return <CommentContainer>{children}</CommentContainer>;
+  return (
+    <CommentContainer>
+      <CommentWrapper>{children}</CommentWrapper>
+    </CommentContainer>
+  );
 }
 
 const CommentContainer = styled.section`
+  position: relative;
+`;
+
+const CommentWrapper = styled.div`
   width: 107.7rem;
   height: 100%;
   min-height: 100vh;
@@ -14,7 +22,6 @@ const CommentContainer = styled.section`
 
   background-color: rgba(13, 14, 17, 0.75);
   backdrop-filter: blur(1.5rem);
-
   padding-left: 6.5rem;
   padding-top: 6.1rem;
   padding-right: 7.5rem;

--- a/src/@components/trackPost/index.tsx
+++ b/src/@components/trackPost/index.tsx
@@ -7,6 +7,7 @@ import usePaly from "../../hooks/common/usePlay";
 import { useTrackDetail } from "../../hooks/queries/tracks";
 import BackButton from "../@common/backButton";
 import Header from "../@common/header";
+import HomeLogo from "../@common/homeLogo";
 import Player from "../@common/player";
 import TrackSearchHeader from "../trackSearch/trackSearchHeader/trackSearchHeader";
 import AudioInfo from "./audioInfo";
@@ -15,7 +16,6 @@ import Comments from "./comments";
 import Download from "./download";
 import ProducerProfile from "./producerProfile";
 import ShowMore from "./showMore";
-import HomeLogo from "../@common/homeLogo";
 
 export const CommentsPlayerContext = createContext<any>({
   playAudio: () => {},
@@ -142,12 +142,6 @@ export default function TrackPost() {
         <HomeLogo />
         <TrackSearchHeader pageType="tracks" />
       </Header>
-      {isOpenComment && (
-        <>
-          <Comments handleClosecomment={handleClosecomment} trackContextPlaying={contextPlaying} />
-          <Player comment />
-        </>
-      )}
 
       <TrackPostWrapper>
         <AudioBasicInfoWrapper>
@@ -165,6 +159,12 @@ export default function TrackPost() {
         <AudioInfo />
       </TrackPostWrapper>
       <CommentBtnIcon onClick={handleOpenComment} />
+      {isOpenComment && (
+        <>
+          <Comments handleClosecomment={handleClosecomment} trackContextPlaying={contextPlaying} />
+          <Player comment />
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
### ✅ 구현 명세
- track post 재생 관련 기능 수정

### 📝 이렇게 구현해봣어요
1. 재생 종료 시에도 계속 ⏸️ 떠져있고, 재킷 이미지 애니메이션 구동되는 이슈 해결
- contextPlaying자체가 true값으로 오고 있었기 때문에, 재생 종료된 경우, stopContextState()되도록 수정했어요

2. 재킷이미지가 댓글창보다 앞으로 나오는 이슈 해결
- z-index 안 쓰고 싶어서, 컴포넌트 위치를 이리저리 옮겨서 해결했습니다
