### PR TITLE
[ feat ] 회원가입 페이지 푸터 구현

### DIFF
--- a/apps/mobile/src/components/signUp/common/Footer.tsx
+++ b/apps/mobile/src/components/signUp/common/Footer.tsx
@@ -1,0 +1,26 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+export default function Footer() {
+  return (
+    <Style.FooterWrapper>
+      <Style.Font>Have an account?</Style.Font>
+      <Link to="/login">
+        <Style.Font color="purple">Log in here</Style.Font>
+      </Link>
+    </Style.FooterWrapper>
+  );
+}
+
+const Style = {
+  Font: styled.p<{ color?: string }>`
+    ${({ theme }) => theme.fonts.Pre_14_R}
+    color: ${({ theme, color }) => (color === 'purple' ? theme.colors.neon_purple : theme.colors.gray4)};
+    margin-left: 0.5ch;
+  `,
+  FooterWrapper: styled.footer`
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  `,
+};


### PR DESCRIPTION
### ✅ 구현 명세
회원가입 페이지 푸터 구현

### 📝 이렇게 구현해봣어요
- 회원가입 페이지에만 있는 로그인하러가기 푸터를 구현했습니다. 
- 클릭했을 때 로그인으로 이동만 하고 별도의 로직이 없기 때문에, Link태그 이용했습니다.

### 🙌🏻 같이 고민했으면 하는 부분
