### PR TITLE
Feat#858 signup/prev next btn

### DIFF
--- a/apps/desktop/src/@components/signUp/stepFooter.tsx
+++ b/apps/desktop/src/@components/signUp/stepFooter.tsx
@@ -1,16 +1,16 @@
-import { useNavigate } from "react-router-dom";
-import { useRecoilState, useSetRecoilState } from "recoil";
-import styled from "styled-components";
-import { SignupCompleteIc, SignupStepBackArrowIc, SignupStepContinueIc } from "../../assets";
-import { SIGNUP_STEP } from "../../core/signUp/stepRenderer";
-import { useJoin } from "../../hooks/queries/user";
-import { loginUserId, loginUserType } from "../../recoil/common/loginUserData";
-import { role } from "../../recoil/common/role";
-import { isNextStep } from "../../recoil/signUp/isNextStep";
-import { joinUserData } from "../../recoil/signUp/joinUserData";
-import { UserType } from "../../type/common/userType";
-import { JoinUserDataPropsType } from "../../type/signUp/joinUserDataType";
-import { StepMainProps } from "../../type/signUp/stepProps";
+import { useNavigate } from 'react-router-dom';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import styled from 'styled-components';
+import { SignupCompleteIc, SignupStepBackArrowIc, SignupStepContinueIc } from '../../assets';
+import { SIGNUP_STEP } from '../../core/signUp/stepRenderer';
+import { useJoin } from '../../hooks/queries/user';
+import { loginUserId, loginUserType } from '../../recoil/common/loginUserData';
+import { role } from '../../recoil/common/role';
+import { isNextStep } from '../../recoil/signUp/isNextStep';
+import { joinUserData } from '../../recoil/signUp/joinUserData';
+import { UserType } from '../../type/common/userType';
+import { JoinUserDataPropsType } from '../../type/signUp/joinUserDataType';
+import { StepMainProps } from '../../type/signUp/stepProps';
 
 export default function StepFooter(props: StepMainProps) {
   const { step, setStep } = props;
@@ -30,7 +30,7 @@ export default function StepFooter(props: StepMainProps) {
 
   function checkPrevStep() {
     if (step === SIGNUP_STEP.EMAIL_PASSWORD) {
-      setRoleType("");
+      setRoleType('');
     }
     setStep(step - 1);
   }
@@ -50,7 +50,7 @@ export default function StepFooter(props: StepMainProps) {
 
   function handleMoveToNextStep() {
     if (checkFinalStep()) {
-      join({ userType: roleType === "producer" ? "producer" : "vocal", formData: userData });
+      join({ userType: roleType === 'producer' ? 'producer' : 'vocal', formData: userData });
     } else {
       setIsSuccess(false);
       checkNextStep();

--- a/apps/mobile/src/components/signUp/SingupStep/StepButtons.tsx
+++ b/apps/mobile/src/components/signUp/SingupStep/StepButtons.tsx
@@ -9,6 +9,26 @@ interface ButtonProp {
   onClick: () => void;
 }
 
+export function Prev(prop: ButtonProp) {
+  const { onClick } = prop;
+
+  return (
+    <Styled.PrevButton type="button" onClick={onClick}>
+      Prev
+    </Styled.PrevButton>
+  );
+}
+
+export function Next(prop: ButtonProp) {
+  const { onClick } = prop;
+
+  return (
+    <Styled.NextButton type="button" disabled={true} onClick={onClick}>
+      Next
+    </Styled.NextButton>
+  );
+}
+
 export default function StepButtons(props: StepMainProps) {
   const { step, setStep } = props;
   const [roleType, setRoleType] = useRecoilState<string | UserType>(role);
@@ -25,30 +45,12 @@ export default function StepButtons(props: StepMainProps) {
   }
 
   return (
-    <>
-      <Prev onClick={moveToPrevStep} />
-      <Next onClick={moveToNextStep} />
-    </>
-  );
-}
-
-function Prev(prop: ButtonProp) {
-  const { onClick } = prop;
-
-  return (
-    <Styled.PrevButton type="button" onClick={onClick}>
-      Prev
-    </Styled.PrevButton>
-  );
-}
-
-function Next(prop: ButtonProp) {
-  const { onClick } = prop;
-
-  return (
-    <Styled.NextButton type="button" disabled={true} onClick={onClick}>
-      Next
-    </Styled.NextButton>
+    <div>
+      <Styled.ButtonWrapper>
+        <Prev onClick={moveToPrevStep} />
+        <Next onClick={moveToNextStep} />
+      </Styled.ButtonWrapper>
+    </div>
   );
 }
 
@@ -58,5 +60,9 @@ const Styled = {
   `,
   NextButton: styled.button<{ disabled: boolean }>`
     color: ${({ theme, disabled }) => (disabled ? theme.colors.gray4 : theme.colors.white)};
+  `,
+  ButtonWrapper: styled.div`
+    display: flex;
+    justify-content: space-between;
   `,
 };

--- a/apps/mobile/src/components/signUp/SingupStep/StepButtons.tsx
+++ b/apps/mobile/src/components/signUp/SingupStep/StepButtons.tsx
@@ -1,0 +1,62 @@
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import { SIGNUP_STEP } from '../../../core/signUp/stepRenderer';
+import { role } from '../../../recoil/common/role';
+import { UserType } from '../../../type/common/userType';
+import { StepMainProps } from '../../../type/signUp/stepProps';
+
+interface ButtonProp {
+  onClick: () => void;
+}
+
+export default function StepButtons(props: StepMainProps) {
+  const { step, setStep } = props;
+  const [roleType, setRoleType] = useRecoilState<string | UserType>(role);
+
+  function moveToNextStep() {
+    setStep(step + 1);
+  }
+
+  function moveToPrevStep() {
+    if (step === SIGNUP_STEP.EMAIL_PASSWORD) {
+      setRoleType('');
+    }
+    setStep(step - 1);
+  }
+
+  return (
+    <>
+      <Prev onClick={moveToPrevStep} />
+      <Next onClick={moveToNextStep} />
+    </>
+  );
+}
+
+function Prev(prop: ButtonProp) {
+  const { onClick } = prop;
+
+  return (
+    <Styled.PrevButton type="button" onClick={onClick}>
+      Prev
+    </Styled.PrevButton>
+  );
+}
+
+function Next(prop: ButtonProp) {
+  const { onClick } = prop;
+
+  return (
+    <Styled.NextButton type="button" disabled={true} onClick={onClick}>
+      Next
+    </Styled.NextButton>
+  );
+}
+
+const Styled = {
+  PrevButton: styled.button`
+    color: ${({ theme }) => theme.colors.gray4};
+  `,
+  NextButton: styled.button<{ disabled: boolean }>`
+    color: ${({ theme, disabled }) => (disabled ? theme.colors.gray4 : theme.colors.white)};
+  `,
+};

--- a/apps/mobile/src/pages/signupStepPage.tsx
+++ b/apps/mobile/src/pages/signupStepPage.tsx
@@ -1,3 +1,13 @@
+import { useState } from 'react';
+import StepButtons from '../components/signUp/SingupStep/StepButtons';
+import { SIGNUP_STEP } from '../core/signUp/stepRenderer';
+
 export default function SignupStepPage() {
-  return <></>;
+  const [step, setStep] = useState<number>(SIGNUP_STEP.ROLE);
+
+  return (
+    <>
+      <StepButtons step={step} setStep={setStep} />
+    </>
+  );
 }


### PR DESCRIPTION
### ✅ 구현 명세
회원가입의 prev, next 버튼을 구현했어요. 

### 📝 이렇게 구현해봣어요
step, setStep을 prop으로 내려주었어요.

### 🙌🏻 같이 고민했으면 하는 부분
데탑 버전에서는 버튼 disabled 여부를 isSuccess라는 이름의 전역변수로 사용했는데, 사실 disabled 여부는 다른 곳이 아니라 오직 회원가입 input(SingupMain에 해당하는 부분)에서만 결정되기 때문에, 리코일로 하는 게 맞을지 좀 고민이 되는 것 같아요.. context로 하기엔 부수적인 코드들이 많아질 것 같고 그냥 prop으로 내려줄까.. 생각중입니다. 결국 두 방법다 SingupMain과 StepButton 컴포넌트를 형제관계로 가지고 있던 데탑과 달리, StepButton을 SignupMain에 종속되게 하는 방법일 듯 하네용...