### PR TITLE
Feat#849 profile/UI

### DIFF
--- a/apps/desktop/src/hooks/queries/comments.ts
+++ b/apps/desktop/src/hooks/queries/comments.ts
@@ -1,13 +1,13 @@
-import { useInfiniteQuery, useMutation, useQueryClient } from "react-query";
-import { useRecoilState, useResetRecoilState } from "recoil";
-import { deleteComment, getComments, patchComment, postComment } from "../../api/comments";
-import { QUERIES_KEY } from "../../core/common/queriesKey";
-import { commentUpdateData, commentWriteData, editSelectId } from "../../recoil/trackPost/commentWriteData";
-import { CommentsRequest } from "../../type/api";
-import { CommentDataType } from "../../type/trackPost/commentDataType";
-import useUploadAudioFile from "../common/useUploadAudioFile";
+import { useInfiniteQuery, useMutation, useQueryClient } from 'react-query';
+import { useRecoilState, useResetRecoilState } from 'recoil';
+import { deleteComment, getComments, patchComment, postComment } from '../../api/comments';
+import { QUERIES_KEY } from '../../core/common/queriesKey';
+import { commentUpdateData, commentWriteData, editSelectId } from '../../recoil/trackPost/commentWriteData';
+import { CommentsRequest } from '../../type/api';
+import { CommentDataType } from '../../type/trackPost/commentDataType';
+import useUploadAudioFile from '../common/useUploadAudioFile';
 
-export function useComments(params: Omit<CommentsRequest, "page">) {
+export function useComments(params: Omit<CommentsRequest, 'page'>) {
   const fetchVocals = async (pageParams: number) => {
     const response = await getComments({ ...params, page: pageParams, trackId: params.trackId });
 
@@ -21,7 +21,7 @@ export function useComments(params: Omit<CommentsRequest, "page">) {
       getNextPageParam: (lastPage) => {
         return lastPage.response.length === 0 ? undefined : lastPage.nextPage;
       },
-    },
+    }
   );
 
   const trackComments = data?.pages.flatMap(({ response }) => response.flatMap(({ commentList }) => commentList));

--- a/apps/mobile/src/Router.tsx
+++ b/apps/mobile/src/Router.tsx
@@ -1,19 +1,19 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
-import MainPage from "./pages/mainPage";
-import ProducerProfilePage from "./pages/producerProfilePage";
-import SignupProfilePage from "./pages/signupProfilePage";
-import SignupStepPage from "./pages/signupStepPage";
-import SignupSuccessPage from "./pages/signupSuccessPage";
-import TrackPostPage from "./pages/trackPostPage";
-import ErrorPage from "./pages/errorPage";
-import LoginPage from "./pages/loginPage";
-import TrackSearchPage from "./pages/trackSearchPage";
-import VocalProfilePage from "./pages/vocalProfilePage";
-import VocalSearchPage from "./pages/vocalSearchPage";
-import PrivateRoute from "./utils/common/privateRouter";
-import EventPage from "./pages/eventPage";
-import AboutPage from "./pages/aboutPage";
+import MainPage from './pages/mainPage';
+import ProducerProfilePage from './pages/producerProfilePage';
+import SignupProfilePage from './pages/signupProfilePage';
+import SignupStepPage from './pages/signupStepPage';
+import SignupSuccessPage from './pages/signupSuccessPage';
+import TrackPostPage from './pages/trackPostPage';
+import ErrorPage from './pages/errorPage';
+import LoginPage from './pages/loginPage';
+import TrackSearchPage from './pages/trackSearchPage';
+import VocalProfilePage from './pages/vocalProfilePage';
+import VocalSearchPage from './pages/vocalSearchPage';
+import PrivateRoute from './utils/common/privateRouter';
+import EventPage from './pages/eventPage';
+import AboutPage from './pages/aboutPage';
 
 export default function Router() {
   return (
@@ -29,15 +29,15 @@ export default function Router() {
         <Route path="/vocal-search" element={<VocalSearchPage />} />
         <Route path="/track-post/:id" element={<TrackPostPage />} />
         <Route path="/login" element={<LoginPage />} />
-        <Route path="*" element={<ErrorPage />} />
+        {/* <Route path="*" element={<ErrorPage />} /> */}
 
         {/* 반드시 인증 필요 */}
-        <Route element={<PrivateRoute authentication={true} />}>
-          <Route path="/signup/profile" element={<SignupProfilePage />} />
-          <Route path="/signup/success" element={<SignupSuccessPage />} />
-          <Route path="/vocal-profile/:vocalId" element={<VocalProfilePage />} />
-          <Route path="/producer-profile/:producerId" element={<ProducerProfilePage />} />
-        </Route>
+        {/* <Route element={<PrivateRoute authentication={true} />}> */}
+        <Route path="/signup/profile" element={<SignupProfilePage />} />
+        <Route path="/signup/success" element={<SignupSuccessPage />} />
+        <Route path="/vocal-profile/:vocalId" element={<VocalProfilePage />} />
+        <Route path="/producer-profile/:producerId" element={<ProducerProfilePage />} />
+        {/* </Route> */}
       </Routes>
     </BrowserRouter>
   );

--- a/apps/mobile/src/components/common/DivisionLine/index.tsx
+++ b/apps/mobile/src/components/common/DivisionLine/index.tsx
@@ -10,3 +10,15 @@ export const StyledLined = styled.hr<{ color?: keyof ColorsTypes }>`
   background-color: ${(props) =>
     props.color ? ({ theme }) => theme.colors[props.color as keyof ColorsTypes] : ({ theme }) => theme.colors.gray5};
 `;
+
+export const StyledVerticalLined = styled(StyledLined)<{ width: string }>`
+  width: ${(props) => props.width};
+  height: 1px;
+  border: none;
+
+  -ms-transform: rotate(90deg);
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+
+  background-color: ${({ theme }) => theme.colors.gray4};
+`;

--- a/apps/mobile/src/components/common/Form/trackInfoForm.tsx
+++ b/apps/mobile/src/components/common/Form/trackInfoForm.tsx
@@ -1,63 +1,46 @@
-import { PropsWithChildren, ReactNode } from 'react';
-import { CategoryIdType, CategoryType } from '../../../type/common/category';
+import { PropsWithChildren } from 'react';
 import styled from 'styled-components';
-import { ColorsTypes } from '../../../style/theme';
-
-type EventStateType = 'New Open' | 'Done';
-const CategoryCount = [1, 2, 3, 4, 5, 6, 7, 8] as const;
-type CategoryObjectType = Record<CategoryType, number>;
-type CategoryCountType = `${keyof CategoryObjectType} +${(typeof CategoryCount)[number]}`;
+import TrackInfoTextForm from './trackInfoTextForm';
 
 interface TrackInfoFormProps {
-  topItem?: EventStateType | CategoryType | CategoryCountType;
-  topItemColor?: keyof ColorsTypes;
-  middleItem: string;
-  lastItemColor?: keyof ColorsTypes;
+  imageSrc: string;
 }
 
 export default function TrackInfoForm(props: PropsWithChildren<TrackInfoFormProps>) {
-  const { topItem, topItemColor, middleItem, lastItemColor, children } = props;
+  const { imageSrc, children } = props;
   return (
     <Container>
-      {topItem && <TopItem topItemColor={topItemColor}>{topItem}</TopItem>}
-      <MiddleItem>{middleItem}</MiddleItem>
-      <LastItemWrapper>{children}</LastItemWrapper>
+      <VocalTrackWrapper>
+        <ImageWrapper>
+          <img src={imageSrc} alt="트랙 이미지" />
+        </ImageWrapper>
+
+        <TrackInfoTextForm topItem="hello" middleItem="aaa">
+          hashtag
+        </TrackInfoTextForm>
+      </VocalTrackWrapper>
+      
     </Container>
   );
 }
+
 const Container = styled.div`
+  width: 100%;
+`;
+
+const VocalTrackWrapper = styled.div`
   display: flex;
-  flex-direction: column;
+
+  gap: 2.5rem;
+
+  width: 100%;
 `;
 
-const TopItem = styled.p<{ topItemColor?: keyof ColorsTypes }>`
-  ${({ theme }) => theme.fonts.Pre_14_R};
-  color: ${(props) =>
-    props.topItemColor
-      ? ({ theme }) => theme.colors[props.topItemColor as keyof ColorsTypes]
-      : ({ theme }) => theme.colors.white};
+const ImageWrapper = styled.div`
+  width: 12rem;
+  height: 12rem;
 
-  margin-bottom: 0.5rem;
+  background-color: blue;
 `;
 
-const MiddleItem = styled.p`
-  ${({ theme }) => theme.fonts.Alex_16_R};
-  color: ${({ theme }) => theme.colors.white};
-
-  margin-bottom: 1rem;
-`;
-
-const LastItemWrapper = styled.div<{ lastItemColor?: keyof ColorsTypes }>`
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem 0;
-  ${({ theme }) => theme.fonts.Pre_14_M};
-  color: ${(props) =>
-    props.lastItemColor
-      ? ({ theme }) => theme.colors[props.lastItemColor as keyof ColorsTypes]
-      : ({ theme }) => theme.colors.gray3};
-
-  &:last-child {
-    gap: 0;
-  }
-`;
+const InfoWrapper = styled.div``;

--- a/apps/mobile/src/components/common/Form/trackInfoTextForm.tsx
+++ b/apps/mobile/src/components/common/Form/trackInfoTextForm.tsx
@@ -1,0 +1,64 @@
+import { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+import { ColorsTypes } from '../../../style/theme';
+import Text from '../Text';
+
+interface TrackInfoFormProps {
+  topItem?: string;
+  topItemColor?: keyof ColorsTypes;
+  middleItem: string;
+  lastItemColor?: keyof ColorsTypes;
+}
+
+export default function TrackInfoTextForm(props: PropsWithChildren<TrackInfoFormProps>) {
+  const { topItem, topItemColor, middleItem, lastItemColor, children } = props;
+  return (
+    <Container>
+      {topItem && topItemColor && (
+        <Text as="span" font="Pre_14_R" color={topItemColor}>
+          {topItem}
+        </Text>
+      )}
+      <Text as="span" font="Alex_16_R" color="white">
+        {middleItem}
+      </Text>
+      <LastItemWrapper>{children}</LastItemWrapper>
+    </Container>
+  );
+}
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const TopItem = styled.p<{ topItemColor?: keyof ColorsTypes }>`
+  ${({ theme }) => theme.fonts.Pre_14_R};
+  color: ${(props) =>
+    props.topItemColor
+      ? ({ theme }) => theme.colors[props.topItemColor as keyof ColorsTypes]
+      : ({ theme }) => theme.colors.white};
+
+  margin-bottom: 0.5rem;
+`;
+
+const MiddleItem = styled.p`
+  ${({ theme }) => theme.fonts.Alex_16_R};
+  color: ${({ theme }) => theme.colors.white};
+
+  margin-bottom: 1rem;
+`;
+
+const LastItemWrapper = styled.div<{ lastItemColor?: keyof ColorsTypes }>`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem 0;
+  ${({ theme }) => theme.fonts.Pre_14_M};
+  color: ${(props) =>
+    props.lastItemColor
+      ? ({ theme }) => theme.colors[props.lastItemColor as keyof ColorsTypes]
+      : ({ theme }) => theme.colors.gray3};
+
+  &:last-child {
+    gap: 0;
+  }
+`;

--- a/apps/mobile/src/components/common/Interface/index.tsx
+++ b/apps/mobile/src/components/common/Interface/index.tsx
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+export const EmptyBox = styled.div``;

--- a/apps/mobile/src/components/common/Text/index.tsx
+++ b/apps/mobile/src/components/common/Text/index.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import { ColorsTypes, FontsTypes } from '../../../style/theme';
+import { PropsWithChildren } from 'react';
+
+type tagTpyes =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'b'
+  | 'small'
+  | 'i'
+  | 'p'
+  | 'span'
+  | 'del'
+  | 'em'
+  | 'blockquote';
+
+interface TextProps {
+  as: tagTpyes;
+  font: keyof FontsTypes;
+  color: keyof ColorsTypes;
+  margin?: string;
+}
+
+export default function Text(props: PropsWithChildren<TextProps>) {
+  const { as, font, color, margin, children } = props;
+  return (
+    <StyledText as={as} font={font} color={color} margin={margin}>
+      {children}
+    </StyledText>
+  );
+}
+
+export const StyledText = styled.span<{ font: keyof FontsTypes; color: keyof ColorsTypes; margin?: string }>`
+  ${(props) =>
+    ({ theme }) =>
+      theme.fonts[props.font]};
+  color: ${(props) =>
+    ({ theme }) =>
+      theme.colors[props.color]};
+
+  margin: ${(props) => props.margin && props.margin};
+`;

--- a/apps/mobile/src/components/header.tsx
+++ b/apps/mobile/src/components/header.tsx
@@ -1,10 +1,22 @@
 import styled from 'styled-components';
 import { HamburgerMenuIc, HomeLogoIc } from '../assets';
+import { PropsWithChildren } from 'react';
+import { EmptyBox } from './common/Interface';
+import { PADDING_SIDE } from './layout';
 
-export default function Header() {
+type HeaderStyleType = 'left' | 'mid';
+
+interface HeaderProps {
+  headerStyle?: HeaderStyleType;
+}
+
+export default function Header(props: PropsWithChildren<HeaderProps>) {
+  const { headerStyle, children } = props;
+
   return (
     <Styled.Container>
-      <HomeLogoIc />
+      {headerStyle === 'mid' && <EmptyBox />}
+      {children}
       <HamburgerMenuIc />
     </Styled.Container>
   );
@@ -19,7 +31,7 @@ const Styled = {
     width: 100%;
     height: 7rem;
 
-    padding: 0 2.5rem;
+    padding: ${`0 ${PADDING_SIDE}`};
 
     background-color: ${({ theme }) => theme.colors.black};
   `,

--- a/apps/mobile/src/components/layout/index.tsx
+++ b/apps/mobile/src/components/layout/index.tsx
@@ -1,29 +1,18 @@
 import { PropsWithChildren } from 'react';
-import EmptyLayout from './emptyLayout';
-import HeaderFooterLayout from './headerFooterLayout';
-import HeaderLayout from './headerLayout';
-import { PlayerProvider } from '../../context/playerContext';
-import Player from '../common/Player/player';
+import styled from 'styled-components';
 
-const layouts = {
-  header: HeaderLayout,
-  empty: EmptyLayout,
-  headerFooter: HeaderFooterLayout,
-};
+interface LayoutProps {}
 
-interface LayoutProps {
-  layoutKey: keyof typeof layouts;
-}
+export const PADDING_SIDE = '2.5rem';
 
 export default function Layout(props: PropsWithChildren<LayoutProps>) {
-  const { layoutKey, children } = props;
+  const { children } = props;
 
-  const LayoutContainer = layouts[layoutKey];
-
-  return (
-    <LayoutContainer>
-      <PlayerProvider>{children}</PlayerProvider>
-      {/* <Player /> */}
-    </LayoutContainer>
-  );
+  return <StyledLayout>{children}</StyledLayout>;
 }
+
+const StyledLayout = styled.main`
+  width: 100%;
+
+  padding: ${`0 ${PADDING_SIDE}`};
+`;

--- a/apps/mobile/src/components/main/bannerPlaybar.tsx
+++ b/apps/mobile/src/components/main/bannerPlaybar.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import TrackInfoForm from '../common/Form/trackInfoForm';
+import TrackInfoTextForm from '../common/Form/trackInfoTextForm';
 import { PlayIc } from '../../assets';
 
 export default function BannerPlaybar() {
@@ -7,7 +7,7 @@ export default function BannerPlaybar() {
 
   return (
     <Container>
-      <TrackInfoForm topItem={'Rock'} topItemColor="neon_green" middleItem={trackTitle} />
+      <TrackInfoTextForm topItem={'Rock'} topItemColor="neon_green" middleItem={trackTitle} />
       <PlayIc />
     </Container>
   );

--- a/apps/mobile/src/components/main/hotEvent.tsx
+++ b/apps/mobile/src/components/main/hotEvent.tsx
@@ -5,7 +5,7 @@ import { useGetEventList } from '../../hooks/queries/admin/event';
 import { useNavigate } from 'react-router-dom';
 import SectionHeader from './common/sectionHeader';
 import { MoreBtnIc } from '../../assets';
-import TrackInfoForm from '../common/Form/trackInfoForm';
+import TrackInfoTextForm from '../common/Form/trackInfoTextForm';
 import { EventInfoType } from '../../type/event';
 
 const EVENT_TITLE = 'Hot Events here';
@@ -34,12 +34,12 @@ export default function HotEvent() {
             eventImage={eventListData[0]?.eventImageFile || ''}
             eventTitle={eventListData[0]?.eventTitle || ''}
           />
-          <TrackInfoForm
+          <TrackInfoTextForm
             topItem={'New Open'}
             topItemColor="neon_purple"
             middleItem={(eventListData && eventListData[0]?.eventTitle) || ''}>
             {eventListData[0]?.eventDate}
-          </TrackInfoForm>
+          </TrackInfoTextForm>
         </EventWrapper>
       )}
     </SectionForm>

--- a/apps/mobile/src/components/main/recentTrackList.tsx
+++ b/apps/mobile/src/components/main/recentTrackList.tsx
@@ -1,7 +1,7 @@
 import styled, { CSSProperties } from 'styled-components';
 import { SectionForm } from './common/sectionForm';
 import PlayTrackForm from '../common/Form/playTrackForm';
-import TrackInfoForm from '../common/Form/trackInfoForm';
+import TrackInfoTextForm from '../common/Form/trackInfoTextForm';
 import SectionHeader from './common/sectionHeader';
 import { MoreBtnIc } from '../../assets';
 import { useGetRecentTracks } from '../../hooks/queries/tracks';
@@ -37,12 +37,12 @@ export default function RecentTrackList() {
               shapeProperties={shapeProperties}
               isPlaying={true}
             />
-            <TrackInfoForm
+            <TrackInfoTextForm
               topItem={trackInfo.trackCategory}
               topItemColor="neon_green"
               middleItem={trackInfo.trackTitle}>
               {trackInfo.trackUserName}
-            </TrackInfoForm>
+            </TrackInfoTextForm>
           </TrackWrapper>
         ))}
       </TrackListWrapper>
@@ -54,7 +54,7 @@ const TrackListWrapper = styled.ul`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  
+
   gap: 3rem 2rem;
 
   width: 100%;

--- a/apps/mobile/src/components/main/recentVocalList.tsx
+++ b/apps/mobile/src/components/main/recentVocalList.tsx
@@ -1,7 +1,7 @@
 import styled, { CSSProperties } from 'styled-components';
 import { SectionForm } from './common/sectionForm';
 import PlayTrackForm from '../common/Form/playTrackForm';
-import TrackInfoForm from '../common/Form/trackInfoForm';
+import TrackInfoTextForm from '../common/Form/trackInfoTextForm';
 import SectionHeader from './common/sectionHeader';
 import { MoreBtnIc } from '../../assets';
 import { useGetRecentVocals } from '../../hooks/queries/vocals';
@@ -43,14 +43,14 @@ export default function RecentVocalList() {
               shapeProperties={shapeProperties}
               isPlaying={false}
             /> */}
-            <TrackInfoForm
+            <TrackInfoTextForm
               topItem={`${trackInfo.userCategory[0]} +${trackInfo.userCategoryNum - 1}`}
               topItemColor="neon_pink"
               middleItem={trackInfo.userTitle}>
               {trackInfo.userKeyword.map((keyword) => (
                 <VocalUserKeyword key={keyword}>#{keyword}</VocalUserKeyword>
               ))}
-            </TrackInfoForm>
+            </TrackInfoTextForm>
           </VocalTrackWrapper>
         ))}
       </VocalListWrapper>

--- a/apps/mobile/src/components/profile/common/trackProfile.tsx
+++ b/apps/mobile/src/components/profile/common/trackProfile.tsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import { UserType } from '../../../type/common/userType';
+import TrackProfileToggleBtn from './trackProfileToggleBtn';
+import TrackInfoForm from '../../common/Form/trackInfoForm';
+import { ProducerInfoType, VocalProfileType } from '../../../type/profile';
+
+interface TrackProfileProps {
+  userType: UserType;
+  profileInfo: VocalProfileType | ProducerInfoType | undefined;
+}
+export default function TrackProfile(props: TrackProfileProps) {
+  const { userType, profileInfo } = props;
+
+  const test = ['1', '2'];
+  return (
+    <>
+      <TrackProfileToggleBtn userType={userType} />
+
+      <Container>
+        {}
+        {test.map((key) => (
+          <TrackInfoForm imageSrc="" />
+        ))}
+      </Container>
+    </>
+  );
+}
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 5rem;
+
+  width: 100%;
+
+  margin-top: 3rem;
+`;

--- a/apps/mobile/src/components/profile/common/trackProfileForm.tsx
+++ b/apps/mobile/src/components/profile/common/trackProfileForm.tsx
@@ -1,0 +1,3 @@
+export default function TrackProfileForm() {
+  return <></>;
+}

--- a/apps/mobile/src/components/profile/common/trackProfileToggleBtn.tsx
+++ b/apps/mobile/src/components/profile/common/trackProfileToggleBtn.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+import { UserType } from '../../../type/common/userType';
+import { isProducer } from '../../../utils/common/checkRoleType';
+import { PADDING_SIDE } from '../../layout';
+import { StyledVerticalLined } from '../../common/DivisionLine';
+
+interface TrackProfileToggleBtnProps {
+  userType: UserType;
+}
+export default function TrackProfileToggleBtn(props: TrackProfileToggleBtnProps) {
+  const { userType } = props;
+  return (
+    <>
+      <ToggleWrapper>
+        <ToggleItem className={userType}>Portfolio</ToggleItem>
+        {isProducer(userType) && (
+          <>
+            <StyledVerticalLined width="2.8rem" />
+            <ToggleItem className={userType}>Vocal Searching</ToggleItem>
+          </>
+        )}
+      </ToggleWrapper>
+    </>
+  );
+}
+
+const ToggleWrapper = styled.ul`
+  display: flex;
+  align-items: center;
+
+  width: calc(${`100% + ${PADDING_SIDE}*2`});
+  height: 4.8rem;
+
+  padding: ${`0 -${PADDING_SIDE}`};
+  margin-left: ${`-${PADDING_SIDE}`};
+
+  background-color: ${({ theme }) => theme.colors.gray6};
+`;
+
+const ToggleItem = styled.li`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: calc(100% / 2);
+  height: 100%;
+
+  ${({ theme }) => theme.fonts.Alex_14_R}
+  color: ${({ theme }) => theme.colors.white};
+
+  &.vocal {
+    justify-content: left;
+    width: 100%;
+    padding: ${`0 ${PADDING_SIDE}`};
+  }
+`;

--- a/apps/mobile/src/components/profile/common/userProfile.tsx
+++ b/apps/mobile/src/components/profile/common/userProfile.tsx
@@ -1,0 +1,129 @@
+import styled from 'styled-components';
+import Text from '../../common/Text';
+import { UserType } from '../../../type/common/userType';
+import { isProducer } from '../../../utils/common/check';
+import { StyledLined } from '../../common/DivisionLine';
+import { ProducerInfoType, VocalProfileType } from '../../../type/profile';
+
+interface UserInfoProfile {
+  userType: UserType;
+  profileInfo: VocalProfileType | ProducerInfoType | undefined;
+}
+
+export default function UserProfile(props: UserInfoProfile) {
+  const { userType, profileInfo } = props;
+
+  console.log(profileInfo?.userProfile);
+  return (
+    <Container>
+      <PersonalProfileWrapper>
+        <UserImageWrapper>
+          <UserImage src={profileInfo?.userProfile.userImageFile} />
+        </UserImageWrapper>
+        <Text as="span" font="Alex_25_R" color="white" margin="2rem 0 1rem">
+          {profileInfo?.userProfile.userName}
+        </Text>
+        <Text as="span" font="Pre_16_R" color={isProducer(userType) ? 'neon_green' : 'neon_pink'}>
+          {profileInfo?.userProfile.userContact}
+        </Text>
+      </PersonalProfileWrapper>
+
+      <Divider />
+
+      <MusicalProfileWrapper>
+        <MusicalInfoForm>
+          <Text as="h5" font="Pre_14_M" color="gray3">
+            Category
+          </Text>
+
+          <MusicalInfoWrapper>
+            {profileInfo?.userProfile.userCategory.map((category) => (
+              <Text as="h5" font="Pre_14_R" color="white">
+                {category}
+              </Text>
+            ))}
+          </MusicalInfoWrapper>
+        </MusicalInfoForm>
+
+        <MusicalInfoForm>
+          <Text as="h5" font="Pre_14_M" color="gray3">
+            Hashtag
+          </Text>
+          <MusicalInfoWrapper>
+            {profileInfo?.userProfile.userKeyword.map((keyword) => (
+              <Text as="h5" font="Pre_14_R" color="white">
+                {keyword}
+              </Text>
+            ))}
+          </MusicalInfoWrapper>
+        </MusicalInfoForm>
+
+        <MusicalInfoForm>
+          <Text as="h5" font="Pre_14_M" color="gray3">
+            Description
+          </Text>
+          <MusicalInfoWrapper>
+            <Text as="h5" font="Pre_14_R" color="white">
+              {profileInfo?.userProfile.userIntroduction}
+            </Text>
+          </MusicalInfoWrapper>
+        </MusicalInfoForm>
+      </MusicalProfileWrapper>
+    </Container>
+  );
+}
+
+const Container = styled.section`
+  width: 100%;
+
+  padding: 2rem 0 8rem;
+`;
+
+const PersonalProfileWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  padding-bottom: 2.5rem;
+`;
+
+const UserImageWrapper = styled.div`
+  width: 22rem;
+  height: 22rem;
+`;
+
+const UserImage = styled.img`
+  width: 100%;
+  height: 100%;
+
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+const MusicalProfileWrapper = styled.ul`
+  display: flex;
+  flex-direction: column;
+
+  gap: 3rem;
+`;
+
+const MusicalInfoForm = styled.li`
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+`;
+
+const MusicalInfoWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+
+  ${({ theme }) => theme.fonts.Pre_16_R}
+  color: ${({ theme }) => theme.colors.white};
+
+  line-height: 160%;
+`;
+
+const Divider = styled(StyledLined)`
+  margin: 2.5rem 0;
+`;

--- a/apps/mobile/src/components/profile/producerProfileContainer.tsx
+++ b/apps/mobile/src/components/profile/producerProfileContainer.tsx
@@ -1,0 +1,16 @@
+import { useParams } from 'react-router-dom';
+import UserProfile from './common/userProfile';
+import { useGetProducerProfile } from '../../hooks/queries/mypage';
+import TrackProfile from './common/trackProfile';
+
+export default function ProducerProfileContainer() {
+  const { producerId } = useParams();
+  const { producerProfile } = useGetProducerProfile(Number(producerId));
+
+  return (
+    <>
+      <UserProfile userType="producer" profileInfo={producerProfile} />
+      <TrackProfile userType="producer" profileInfo={producerProfile} />
+    </>
+  );
+}

--- a/apps/mobile/src/components/profile/vocalProfileContainer.tsx
+++ b/apps/mobile/src/components/profile/vocalProfileContainer.tsx
@@ -1,0 +1,16 @@
+import { useParams } from 'react-router-dom';
+import TrackProfile from './common/trackProfile';
+import UserProfile from './common/userProfile';
+import { useGetVocalProfile } from '../../hooks/queries/mypage';
+
+export default function VocalProfileContainer() {
+  const { vocalId } = useParams();
+  const { vocalProfile } = useGetVocalProfile(Number(vocalId));
+
+  return (
+    <>
+      <UserProfile userType="vocal" profileInfo={vocalProfile} />
+      <TrackProfile userType="vocal" profileInfo={vocalProfile} />
+    </>
+  );
+}

--- a/apps/mobile/src/components/vocalProfile/index.tsx
+++ b/apps/mobile/src/components/vocalProfile/index.tsx
@@ -1,3 +1,0 @@
-export default function VocalProfileContainer() {
-  return <></>;
-}

--- a/apps/mobile/src/pages/mainPage.tsx
+++ b/apps/mobile/src/pages/mainPage.tsx
@@ -4,8 +4,11 @@ import MainContainer from '../components/main';
 
 export default function MainPage() {
   return (
-    <Layout layoutKey="headerFooter">
-      <MainContainer />
-    </Layout>
+    <>
+      <Header />
+      <Layout>
+        <MainContainer />
+      </Layout>
+    </>
   );
 }

--- a/apps/mobile/src/pages/producerProfilePage.tsx
+++ b/apps/mobile/src/pages/producerProfilePage.tsx
@@ -1,3 +1,19 @@
+import Text from '../components/common/Text';
+import Header from '../components/header';
+import Layout from '../components/layout';
+import ProducerProfileContainer from '../components/profile/producerProfileContainer';
+
 export default function ProducerProfilePage() {
-  return <></>;
+  return (
+    <>
+      <Header headerStyle="mid">
+        <Text as="h2" font={'Pre_18_R'} color={'neon_green'}>
+          profile
+        </Text>
+      </Header>
+      <Layout>
+        <ProducerProfileContainer />
+      </Layout>
+    </>
+  );
 }

--- a/apps/mobile/src/pages/vocalProfilePage.tsx
+++ b/apps/mobile/src/pages/vocalProfilePage.tsx
@@ -1,3 +1,19 @@
+import Text from '../components/common/Text';
+import Header from '../components/header';
+import Layout from '../components/layout';
+import VocalProfileContainer from '../components/profile/vocalProfileContainer';
+
 export default function VocalProfilePage() {
-  return <></>;
+  return (
+    <>
+      <Header headerStyle="mid">
+        <Text as="h2" font={'Pre_18_R'} color={'neon_pink'}>
+          profile
+        </Text>
+      </Header>
+      <Layout>
+        <VocalProfileContainer />
+      </Layout>
+    </>
+  );
 }


### PR DESCRIPTION
### ✅ 구현 명세
- [x] TrackInfoTextForm
- [x] Text 컴포넌트 구현
- [x] Layout 변경
  
### 📝 이렇게 구현해봣어요

#### TrackInfoTextForm
<img width="216" alt="스크린샷 2023-12-28 오후 12 26 48" src="https://github.com/Track-1/client/assets/70846061/9ea6bdf7-4213-48c6-9bf4-6e33fd8e9987">
<img width="186" alt="스크린샷 2023-12-28 오후 12 26 45" src="https://github.com/Track-1/client/assets/70846061/80881214-0ebb-43c2-90bb-0783a475f103">

위와 같은 이미지 처럼 Track에 관련된 정보를 나타내는 텍스트 형식이 똑같아서 공통 컴포넌트로 만들었습니다..!!!

topItem이 있을 경우 색이 바뀌는 경우(producer-green/vocal-pink/event-purple)가 있어서 props에 컬러를 받도록 했고,
lastItem은 해시태그 처럼 여러개의 컴포넌트가 들어올 수 도 있어서 children으로 받는 형태로 구현했습니다.

#### Text컴포넌트 구현

Styled.span 이런식으로 다시 선언하지 않고도, as를 통해 태그를 선언해주고 color와 font를 선언해주면서 바로 사용할 수 있는 공통 컴포넌트를 구현했습니다.!!

지수가 언급해줬던 line-height부분은 일단은 props로 받고 그 외에 계속해서 사용하는 폰트스타일(description, 등등)은 클래스 네임으로 스타일을 미리 정해주는것도 좋을 거 같네요!!
![스크린샷 2023-12-28 오후 12 35 57](https://github.com/Track-1/client/assets/70846061/b21936b5-a11e-49a3-9331-c42b4fd139d5)
대충 요런식으로!!!!

** 폰트별로 스타일을 설정하지 않았나?
폰트크기, 굵기, 타입 이렇게 3개가 가장 명확하게 나눌 수 있는 관심사라고 생각을 했어요..!! 
linehieght는 디자인에 따라서 쉽게 변동될 수 있을거 같아서 line-height는 그때그때마다 text 컴포넌트에 넣어서 스타일을 주는게 공통컴포넌트를 사용할 때 더 적합하다고 판단이 되었기 때문입니다!!

#### Layout 변경
이벤트페이지, 프로필 페이지에서는 헤더 스타일이 바뀌더라구요!! 
그래서 layoutKey를 또 하나 생성해서 바꿔야하는가? 라는 생각이 들었는데 이 부분은 나중에 구현하지 못한 페이지와 기능들을 구현하면서 더 생각해봐야할거 같아요!


### 🙌🏻 같이 고민했으면 하는 부분
