### PR TITLE
[ feat ] 회원가입 1단계 role 구현

### DIFF
--- a/apps/mobile/src/components/signUp/SignupStep/Role/Card.tsx
+++ b/apps/mobile/src/components/signUp/SignupStep/Role/Card.tsx
@@ -1,0 +1,98 @@
+import styled from 'styled-components';
+import { theme } from '../../../../style/theme';
+
+interface CardProps {
+  color: string;
+  isSelected: boolean;
+  title: string;
+  description: string;
+  onClick: () => void;
+}
+
+export default function Card(props: CardProps) {
+  const { color, isSelected, title, description, onClick } = props;
+
+  return (
+    <Styled.CardContainer color={isSelected ? color : theme.colors.gray5}>
+      <Styled.Header>
+        <Styled.Title>{title}</Styled.Title>
+        <i onClick={onClick}>
+          {isSelected ? (
+            <Styled.CheckedCircle color={color}>
+              <Styled.CheckedInlineCircle color={color} />
+            </Styled.CheckedCircle>
+          ) : (
+            <Styled.BlankCheckCircle />
+          )}
+        </i>
+      </Styled.Header>
+      <Styled.Description color={isSelected ? color : theme.colors.gray3}>{description}</Styled.Description>
+    </Styled.CardContainer>
+  );
+}
+
+const Styled = {
+  CardContainer: styled.article`
+    display: flex;
+    flex-direction: column;
+
+    width: 100%;
+    height: 13.4rem;
+    padding: 2.5rem;
+    gap: 2rem;
+
+    border: 1px solid ${({ color }) => color};
+    border-radius: 1rem;
+    background: linear-gradient(115deg, #1e2125 -7.24%, #141517 24.25%, #141517 34.53%, #141517 60.87%);
+  `,
+  Header: styled.header`
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  `,
+  Title: styled.h1`
+    color: ${({ theme }) => theme.colors.white};
+
+    ${({ theme }) => theme.fonts.Alex_20_R};
+
+    line-height: 140%;
+    letter-spacing: -0.02rem;
+  `,
+  Description: styled.p<{ color: string }>`
+    color: ${({ color }) => color};
+
+    ${({ theme }) => theme.fonts.Pre_14_R};
+    white-space: pre;
+
+    line-height: 130%;
+    letter-spacing: -0.014rem;
+  `,
+  BlankCheckCircle: styled.div`
+    width: 2rem;
+    height: 2rem;
+    flex-shrink: 0;
+
+    border: 1px solid ${({ theme }) => theme.colors.gray5};
+    border-radius: 50%;
+  `,
+  CheckedCircle: styled.div<{ color: string }>`
+    display: flex;
+
+    width: 2rem;
+    height: 2rem;
+
+    flex-shrink: 0;
+
+    border: 1px solid ${({ color }) => color};
+    border-radius: 50%;
+  `,
+  CheckedInlineCircle: styled.div<{ color: string }>`
+    margin: auto;
+
+    width: 1rem;
+    height: 1rem;
+
+    border-radius: 50%;
+    background-color: ${({ color }) => color};
+  `,
+};

--- a/apps/mobile/src/components/signUp/SignupStep/Role/index.tsx
+++ b/apps/mobile/src/components/signUp/SignupStep/Role/index.tsx
@@ -1,0 +1,56 @@
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import { ROLE } from '../../../../core/common/roleType';
+import { role } from '../../../../recoil/common/role';
+import { theme } from '../../../../style/theme';
+import { UserType } from '../../../../type/common/userType';
+import Card from './Card';
+
+const ROLE_TITLE = {
+  PRODUCER: 'Producer',
+  VOCAL: 'Vocal',
+} satisfies Record<string, string>;
+
+const ROLE_DESCRIPTION = {
+  PRODUCER: 'You can upload the Vocal Searching \ntrack by signing up with a producer account.',
+  VOCAL: 'You can search for limitless chance and \nmake your own musician profile.',
+} satisfies Record<string, string>;
+
+export default function Role() {
+  const [selectedRole, setSelectedRole] = useRecoilState<string | UserType>(role);
+
+  function handleSelectRole(role: string) {
+    setSelectedRole(role);
+  }
+
+  function checkIsSelected(role: string) {
+    return selectedRole === role;
+  }
+
+  return (
+    <Styled.RoleSection>
+      <Card
+        color={theme.colors.neon_green}
+        isSelected={checkIsSelected(ROLE.PRODUCER)}
+        title={ROLE_TITLE.PRODUCER}
+        description={ROLE_DESCRIPTION.PRODUCER}
+        onClick={() => handleSelectRole(ROLE.PRODUCER)}
+      />
+      <Card
+        color={theme.colors.neon_pink}
+        isSelected={checkIsSelected(ROLE.VOCAL)}
+        title={ROLE_TITLE.VOCAL}
+        description={ROLE_DESCRIPTION.VOCAL}
+        onClick={() => handleSelectRole(ROLE.VOCAL)}
+      />
+    </Styled.RoleSection>
+  );
+}
+
+const Styled = {
+  RoleSection: styled.section`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  `,
+};

--- a/apps/mobile/src/recoil/common/role.ts
+++ b/apps/mobile/src/recoil/common/role.ts
@@ -1,11 +1,10 @@
-import { atom } from "recoil";
-import { recoilPersist } from "recoil-persist";
-import { ROLE } from "../../core/common/roleType";
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
 
 const { persistAtom } = recoilPersist();
 
 export const role = atom({
-  key: "role",
-  default: ROLE.PRODUCER,
+  key: 'role',
+  default: null,
   effects_UNSTABLE: [persistAtom],
 });

--- a/apps/mobile/src/type/common/userType.ts
+++ b/apps/mobile/src/type/common/userType.ts
@@ -1,1 +1,1 @@
-export type UserType = "producer" | "vocal";
+export type UserType = 'producer' | 'vocal' | null;


### PR DESCRIPTION
### ✅ 구현 명세
- 회원가입 1단계 role을 구현했어요.

### 📝 이렇게 구현해봣어요
- 이 컴포넌트에서밖에 사용되지 않는 ROLE_TITLE, ROLE_DESCRIPTION은 컴포넌트 파일에서 전역적으로 선언해주었어요. 
- Card 컴포넌트를 만들고 값들을 prop으로 내려주었는데, Card 컴포넌트 내에서는 정확한 값들을 알아야할 필요성이 없기때문에 추상화하려고 했어요. 

### 🙌🏻 같이 고민했으면 하는 부분
