### PR TITLE
feat: 사파리 이슈 안내 모달 구현

### DIFF
--- a/apps/desktop/src/@components/upload/producerUploadBody.tsx
+++ b/apps/desktop/src/@components/upload/producerUploadBody.tsx
@@ -1,26 +1,29 @@
-import styled from "styled-components";
-import CategoryInfo from "./categotyInfo";
-import FileUploadInfo from "./fileUploadInfo";
-import UploadTitle from "./uploadTitle";
-import HashtagInfo from "./hashtagInfo";
-import DescriptionInfo from "./descriptionInfo";
-import { ImageInfo } from "./imageInfo";
-import { useSelect } from "../../hooks/common/useSelect";
-import { CategoryIdType, UpperCategoryType } from "../../type/common/category";
-import { FormProvider, useForm } from "react-hook-form";
-import { SelectCategoryContext } from "../../context/selectCategoryContext";
-import Header from "../@common/header";
-import BackButton from "../@common/backButton";
-import UploadHeader from "./uploadHeader";
-import { UserPortfolioType } from "../../type/profile";
-import { useUploadProducerPortfolio } from "../../hooks/queries/mypage";
-import { UploadInputType } from "../../type/common/upload";
-import UploadProducerDefaultImg from "../../assets/image/uploadProducerDefaultImg.png";
-import { useUploadTrack } from "../../hooks/queries/tracks";
-import { useParams } from "react-router-dom";
-import { CategoryId } from "../../core/common/categories";
-import { createFileName } from "../../utils/common/createFileName";
-import { TEXT_LIMIT } from "../../core/common/textLimit";
+import { isSafari } from 'react-device-detect';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import UploadProducerDefaultImg from '../../assets/image/uploadProducerDefaultImg.png';
+import { SelectCategoryContext } from '../../context/selectCategoryContext';
+import { CategoryId } from '../../core/common/categories';
+import { TEXT_LIMIT } from '../../core/common/textLimit';
+import useModalState from '../../hooks/common/useModalState';
+import { useSelect } from '../../hooks/common/useSelect';
+import { useUploadProducerPortfolio } from '../../hooks/queries/mypage';
+import { useUploadTrack } from '../../hooks/queries/tracks';
+import { CategoryIdType, UpperCategoryType } from '../../type/common/category';
+import { UploadInputType } from '../../type/common/upload';
+import { UserPortfolioType } from '../../type/profile';
+import { createFileName } from '../../utils/common/createFileName';
+import BackButton from '../@common/backButton';
+import Header from '../@common/header';
+import CategoryInfo from './categotyInfo';
+import DescriptionInfo from './descriptionInfo';
+import FileUploadInfo from './fileUploadInfo';
+import HashtagInfo from './hashtagInfo';
+import { ImageInfo } from './imageInfo';
+import SafariIssueMdoal from './safariIssueModal';
+import UploadHeader from './uploadHeader';
+import UploadTitle from './uploadTitle';
 
 type ProducerUploadBodyyProps =
   | {
@@ -43,22 +46,22 @@ export default function ProducerUploadBody(props: ProducerUploadBodyyProps) {
   const { uploadTrack } = useUploadTrack();
   const { selectedOption, selectOption } = useSelect<CategoryIdType | null>(
     false,
-    CategoryId[prevUploadData?.portfolioCategory.toUpperCase() as UpperCategoryType],
+    CategoryId[prevUploadData?.portfolioCategory.toUpperCase() as UpperCategoryType]
   );
 
   emptyList.items.add(
-    new File([prevUploadData?.portfolioAudioFileName ?? ""], prevUploadData?.portfolioAudioFileName ?? "", {
-      type: "mp3",
-    }),
+    new File([prevUploadData?.portfolioAudioFileName ?? ''], prevUploadData?.portfolioAudioFileName ?? '', {
+      type: 'mp3',
+    })
   );
 
   const methods = useForm({
     defaultValues: {
-      image: isEditPage ? prevUploadData?.portfolioImageFile ?? "" : "",
-      title: isEditPage ? prevUploadData?.portfolioTitle ?? "" : "",
+      image: isEditPage ? prevUploadData?.portfolioImageFile ?? '' : '',
+      title: isEditPage ? prevUploadData?.portfolioTitle ?? '' : '',
       audioFile: isEditPage ? emptyList.files ?? defaultList.files : defaultList.files,
-      hashtag: isEditPage ? prevUploadData?.portfolioKeyword ?? [""] : [""],
-      description: "",
+      hashtag: isEditPage ? prevUploadData?.portfolioKeyword ?? [''] : [''],
+      description: '',
     },
   });
 
@@ -66,16 +69,16 @@ export default function ProducerUploadBody(props: ProducerUploadBodyyProps) {
     if (selectedOption === null) return;
 
     const formData = new FormData();
-    formData.append("portfolioTitle", data.title);
-    formData.append("portfolioCategory", selectedOption);
-    formData.append("portfolioAudioFile", data.audioFile[0]);
+    formData.append('portfolioTitle', data.title);
+    formData.append('portfolioCategory', selectedOption);
+    formData.append('portfolioAudioFile', data.audioFile[0]);
     data.hashtag.forEach((tag, idx) => {
       if (tag.length === 0) return;
       formData.append(`portfolioContent${idx}`, tag);
     });
-    formData.append("portfolioImageFile", data.image[0] ?? UploadProducerDefaultImg);
-    formData.append("portfolioAudioFileName", createFileName(data.audioFile[0], TEXT_LIMIT.UPLOAD_AUDIO));
-    formData.append("portfolioIntroduction", data.description);
+    formData.append('portfolioImageFile', data.image[0] ?? UploadProducerDefaultImg);
+    formData.append('portfolioAudioFileName', createFileName(data.audioFile[0], TEXT_LIMIT.UPLOAD_AUDIO));
+    formData.append('portfolioIntroduction', data.description);
 
     return formData;
   }
@@ -84,36 +87,39 @@ export default function ProducerUploadBody(props: ProducerUploadBodyyProps) {
     if (selectedOption === null) return;
 
     const formData = new FormData();
-    formData.append("trackTitle", data.title);
-    formData.append("trackCategory ", selectedOption);
-    formData.append("trackAudioFile", data.audioFile[0]);
+    formData.append('trackTitle', data.title);
+    formData.append('trackCategory ', selectedOption);
+    formData.append('trackAudioFile', data.audioFile[0]);
     data.hashtag.forEach((tag, idx) => {
       if (tag.length === 0) return;
       formData.append(`trackKeywordt${idx}`, tag);
     });
-    formData.append("trackImageFile", data.image[0] ?? UploadProducerDefaultImg);
-    formData.append("trackAudioFileName", String(data.audioFile));
-    formData.append("trackIntroduction", data.description);
+    formData.append('trackImageFile', data.image[0] ?? UploadProducerDefaultImg);
+    formData.append('trackAudioFileName', String(data.audioFile));
+    formData.append('trackIntroduction', data.description);
 
     return formData;
   }
 
   function upload(data: UploadInputType) {
-    if (uploadType === "portfolio") {
+    if (uploadType === 'portfolio') {
       const uploadData = createProducerUploadFormData(data);
       uploadData && uploadProducerPortfolio(uploadData);
       return;
     }
 
-    if (uploadType === "vocal-searching") {
+    if (uploadType === 'vocal-searching') {
       const uploadData = createTrackUploadFormData(data);
       uploadData && uploadTrack(uploadData);
       return;
     }
   }
 
+  const { isOpen, onClose } = useModalState(true);
+
   return (
     <FormProvider {...methods}>
+      {isSafari && isOpen && <SafariIssueMdoal isOpen={isOpen} onClose={onClose} />}
       <form
         onSubmit={methods.handleSubmit((data) => {
           upload(data);

--- a/apps/desktop/src/@components/upload/safariIssueModal.tsx
+++ b/apps/desktop/src/@components/upload/safariIssueModal.tsx
@@ -1,0 +1,68 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import styled from 'styled-components';
+import { SignUpModalXIc } from '../../assets';
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function SafariIssueMdoal(props: ModalProps) {
+  const { isOpen, onClose, ...restProps } = props;
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={onClose}>
+      <Dialog.Portal>
+        <Styled.Background>
+          <Styled.ModalBox {...restProps}>
+            <>
+              사파리로 파일 업로드 시 오류가 발생할 수 있습니다. 오류가 발생한다면, 크롬으로 접속하여 주시기 바랍니다.
+              <br /> <br />
+              If an error occurs when uploading files with Safari, please try accessing it using Chrome.
+            </>
+            <Styled.CloseIconWrapper>
+              <Styled.CloseIcon />
+            </Styled.CloseIconWrapper>
+          </Styled.ModalBox>
+        </Styled.Background>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+const Styled = {
+  CloseIconWrapper: styled(Dialog.Close)`
+    display: flex;
+    align-items: flex-start;
+  `,
+  CloseIcon: styled(SignUpModalXIc)`
+    margin: -1rem 0 1rem;
+  `,
+  Background: styled(Dialog.Overlay)`
+    background: rgba(0, 0, 0, 0.8);
+    position: fixed;
+    z-index: 1000;
+    inset: 0;
+    animation: overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  `,
+  ModalBox: styled(Dialog.Content)`
+    display: flex;
+    border-radius: 1rem;
+    border: 1px solid #313338;
+    background: rgba(14, 15, 19, 0.8);
+
+    backdrop-filter: blur(10px);
+    box-shadow: hsl(206 22% 7% / 35%) 0px 10px 38px -10px, hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 90vw;
+    max-width: 65rem;
+    max-height: 40rem;
+    padding: 4rem 2rem 4rem 4rem;
+    animation: contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+    color: ${({ theme }) => theme.colors.gray2};
+    ${({ theme }) => theme.fonts.pretendard_text20};
+  `,
+};

--- a/apps/desktop/src/@components/upload/vocalUploadBody.tsx
+++ b/apps/desktop/src/@components/upload/vocalUploadBody.tsx
@@ -1,24 +1,27 @@
-import styled from "styled-components";
-import UploadVocalLayoutImg from "../../assets/image/uploadVocalLayoutImg.png";
-import CategoryInfo from "./categotyInfo";
-import FileUploadInfo from "./fileUploadInfo";
-import UploadTitle from "./uploadTitle";
-import HashtagInfo from "./hashtagInfo";
-import DescriptionInfo from "./descriptionInfo";
-import { useUploadVocalPortfolio } from "../../hooks/queries/mypage";
-import { FormProvider, useForm } from "react-hook-form";
-import { SelectCategoryContext } from "../../context/selectCategoryContext";
-import Header from "../@common/header";
-import BackButton from "../@common/backButton";
-import UploadHeader from "./uploadHeader";
-import { useSelect } from "../../hooks/common/useSelect";
-import { CategoryIdType, UpperCategoryType } from "../../type/common/category";
-import { ImageInfo } from "./imageInfo";
-import { UserPortfolioType } from "../../type/profile";
-import { UploadInputType } from "../../type/common/upload";
-import UploadVocalDefaultImg from "../../assets/image/uploadVocalDefaultImg.png";
-import { CategoryId } from "../../core/common/categories";
-import { useParams } from "react-router-dom";
+import { isSafari } from 'react-device-detect';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import UploadVocalDefaultImg from '../../assets/image/uploadVocalDefaultImg.png';
+import UploadVocalLayoutImg from '../../assets/image/uploadVocalLayoutImg.png';
+import { SelectCategoryContext } from '../../context/selectCategoryContext';
+import { CategoryId } from '../../core/common/categories';
+import useModalState from '../../hooks/common/useModalState';
+import { useSelect } from '../../hooks/common/useSelect';
+import { useUploadVocalPortfolio } from '../../hooks/queries/mypage';
+import { CategoryIdType, UpperCategoryType } from '../../type/common/category';
+import { UploadInputType } from '../../type/common/upload';
+import { UserPortfolioType } from '../../type/profile';
+import BackButton from '../@common/backButton';
+import Header from '../@common/header';
+import CategoryInfo from './categotyInfo';
+import DescriptionInfo from './descriptionInfo';
+import FileUploadInfo from './fileUploadInfo';
+import HashtagInfo from './hashtagInfo';
+import { ImageInfo } from './imageInfo';
+import SafariIssueMdoal from './safariIssueModal';
+import UploadHeader from './uploadHeader';
+import UploadTitle from './uploadTitle';
 
 type VocalUploadBodyProps =
   | {
@@ -40,22 +43,22 @@ export default function VocalUploadBody(props: VocalUploadBodyProps) {
   const { uploadVocalPortfolio } = useUploadVocalPortfolio();
   const { selectedOption, selectOption } = useSelect<CategoryIdType | null>(
     false,
-    CategoryId[prevUploadData?.portfolioCategory.toUpperCase() as UpperCategoryType],
+    CategoryId[prevUploadData?.portfolioCategory.toUpperCase() as UpperCategoryType]
   );
 
   emptyList.items.add(
-    new File([prevUploadData?.portfolioAudioFileName ?? ""], prevUploadData?.portfolioAudioFileName ?? "", {
-      type: "mp3",
-    }),
+    new File([prevUploadData?.portfolioAudioFileName ?? ''], prevUploadData?.portfolioAudioFileName ?? '', {
+      type: 'mp3',
+    })
   );
 
   const methods = useForm({
     defaultValues: {
-      image: isEditPage ? prevUploadData?.portfolioImageFile ?? "" : "",
-      title: isEditPage ? prevUploadData?.portfolioTitle ?? "" : "",
+      image: isEditPage ? prevUploadData?.portfolioImageFile ?? '' : '',
+      title: isEditPage ? prevUploadData?.portfolioTitle ?? '' : '',
       audioFile: isEditPage ? emptyList.files ?? defaultList.files : defaultList.files,
       hashtag: isEditPage ? prevUploadData?.portfolioKeyword ?? [] : [],
-      description: "",
+      description: '',
     },
   });
 
@@ -63,21 +66,24 @@ export default function VocalUploadBody(props: VocalUploadBodyProps) {
     if (selectedOption === null) return;
 
     const formData = new FormData();
-    formData.append("portfolioTitle", data.title);
-    formData.append("portfolioCategory", selectedOption);
-    formData.append("portfolioAudioFile", data.audioFile[0]);
+    formData.append('portfolioTitle', data.title);
+    formData.append('portfolioCategory', selectedOption);
+    formData.append('portfolioAudioFile', data.audioFile[0]);
     data.hashtag.forEach((tag, idx) => {
       if (tag.length === 0) return;
       formData.append(`portfolioContent${idx}`, tag);
     });
-    formData.append("portfolioImageFile", data.image ?? UploadVocalDefaultImg);
-    formData.append("portfolioAudioFileName", String(data.audioFile));
+    formData.append('portfolioImageFile', data.image ?? UploadVocalDefaultImg);
+    formData.append('portfolioAudioFileName', String(data.audioFile));
 
     return formData;
   }
 
+  const { isOpen, onClose } = useModalState(true);
+
   return (
     <FormProvider {...methods}>
+      {isSafari && isOpen && <SafariIssueMdoal isOpen={isOpen} onClose={onClose} />}
       <form
         onSubmit={methods.handleSubmit((data) => {
           const uploadData = createVocalUploadFormData(data);

--- a/apps/desktop/src/hooks/common/useModalState.ts
+++ b/apps/desktop/src/hooks/common/useModalState.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+export default function useModalState(initialState: boolean) {
+  const [isOpen, setIsOpen] = useState<boolean>(initialState);
+
+  function onClose() {
+    setIsOpen(false);
+  }
+
+  function onOpen() {
+    setIsOpen(true);
+  }
+
+  return { isOpen, onClose, onOpen };
+}


### PR DESCRIPTION
### ✅ 구현 명세
- 사파리에서 업로드 페이지 접속 시, 안내 모달을 띄웠어요.

### 📝 이렇게 구현해봣어요

<img width="1440" alt="스크린샷 2024-01-18 오후 4 34 58" src="https://github.com/Track-1/client/assets/76681519/220b20d9-f8b2-4aab-8ef0-6e5f9f7c8b35">

- 기존에 모바일/데탑 구분을 위해 설치되어있던 react-device-detect의 isSafari 기능을 이용했어요.


### 🙌🏻 같이 고민했으면 하는 부분
- 모달은 내용은 SafariIssueMdoal.tsx안에서 수정하시면 됩니다!
- 내용적인 수정은 자유롭게 커스터마이징하시면 될 듯 합니다!